### PR TITLE
Fix Preferences window crash

### DIFF
--- a/src/PreferenceWindow.cpp
+++ b/src/PreferenceWindow.cpp
@@ -29,13 +29,14 @@ PreferenceWindow::PreferenceWindow(Preferences* preferences)
 	:BWindow(BRect(), B_TRANSLATE("Preferences"), B_TITLED_WINDOW,
 		B_NOT_ZOOMABLE | B_NOT_RESIZABLE| B_AUTO_UPDATE_SIZE_LIMITS)
 {
-	fCurrentPreferences = preferences;
-
+	
+	fCurrentPreferences = new Preferences();
 	fStartPreferences = new Preferences();
-	*fStartPreferences = *fCurrentPreferences;
-
 	fTempPreferences = new Preferences();
-	*fTempPreferences = *fCurrentPreferences;
+
+	fCurrentPreferences->Copy(preferences);
+	fStartPreferences->Copy(fCurrentPreferences);
+	fTempPreferences->Copy(fCurrentPreferences);
 
 	_InitInterface();
 	CenterOnScreen();
@@ -75,7 +76,7 @@ PreferenceWindow::MessageReceived(BMessage* message)
 
 		case kApplyPreferencesMessage:
 		{
-			*fCurrentPreferences = *fTempPreferences;
+			fCurrentPreferences = fTempPreferences;
 			fApplyButton->SetEnabled(false);
 			BMessage changed(kAppPreferencesChanged);
 			be_app->PostMessage(&changed);
@@ -84,7 +85,7 @@ PreferenceWindow::MessageReceived(BMessage* message)
 
 		case kRevertPreferencesMessage:
 		{
-			*fTempPreferences = *fStartPreferences;
+			fTempPreferences->Copy(fStartPreferences);
 			fRevertButton->SetEnabled(false);
 			fApplyButton->SetEnabled(true);
 			_SyncPreferences(fTempPreferences);

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -129,6 +129,17 @@ Preferences::Save(const char* filename)
 }
 
 
+void
+Preferences::Copy(Preferences* p)
+{
+	fSettingsPath = p->fSettingsPath;
+	fStartOfWeekOffset = p->fStartOfWeekOffset;
+	fHeaderVisible = p->fHeaderVisible;
+	fMainWindowRect = p->fMainWindowRect;
+	fEventWindowRect = p->fEventWindowRect;
+}
+
+
 Preferences&
 Preferences::operator =(Preferences p)
 {

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -18,6 +18,7 @@ public:
 	void					Load(const char* filename);
 	void					Save(const char* filename);
 
+	void					Copy(Preferences* p);
 	Preferences&			operator =(Preferences p);
 
 	BPath					fSettingsPath;


### PR DESCRIPTION
Fixes #51-- uses a new Copy method, instead of dereferenced assignment.