### PR TITLE
Fix #51: add return value to the preference class assignment operator overloading

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -130,11 +130,13 @@ Preferences::Save(const char* filename)
 
 
 Preferences&
-Preferences::operator =(Preferences p)
+Preferences::operator =(const Preferences& p)
 {
 	fSettingsPath = p.fSettingsPath;
 	fStartOfWeekOffset = p.fStartOfWeekOffset;
 	fHeaderVisible = p.fHeaderVisible;
 	fMainWindowRect = p.fMainWindowRect;
 	fEventWindowRect = p.fEventWindowRect;
+
+	return *this;
 }

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -18,7 +18,7 @@ public:
 	void					Load(const char* filename);
 	void					Save(const char* filename);
 
-	Preferences&			operator =(Preferences p);
+	Preferences&			operator =(const Preferences& p);
 
 	BPath					fSettingsPath;
 


### PR DESCRIPTION
Fix #51: The preference class assignment operator overloading was missing a return value which lead to undefined behavior.  This appears to be the root cause of the crash that occurred when attempting to open the preference window.  These changes seem to address that issue. 