### PR TITLE
Fix issue with event list

### DIFF
--- a/src/DayView.cpp
+++ b/src/DayView.cpp
@@ -61,6 +61,11 @@ DayView::SetDate(const BDate& date)
 	fDate = date;
 }
 
+void DayView::SetMode(int32 mode)
+{
+	this->mode = mode;
+}
+
 void
 DayView::LoadEvents()
 {

--- a/src/DayView.h
+++ b/src/DayView.h
@@ -32,6 +32,7 @@ public:
 
 		void			SetDate(const BDate& date);
 		void			LoadEvents();
+		void			SetMode(int32 mode);
 		void			SetEventListPopUpEnabled(bool state);
 		static	int		CompareFunc(const void* a, const void* b);
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -331,6 +331,7 @@ MainWindow::_UpdateDayView()
 {
 	BDate date = _GetSelectedCalendarDate();
 	fDayView->SetDate(date);
+	fDayView->SetMode(kDayView);
 	LockLooper();
 	fDayView->LoadEvents();
 	UnlockLooper();

--- a/src/db/SQLiteManager.cpp
+++ b/src/db/SQLiteManager.cpp
@@ -386,7 +386,7 @@ SQLiteManager::GetEventsOfDay(BDate& date)
 
 
 BList*
-SQLiteManager::GetEventsOfWeek(BDate& date)
+SQLiteManager::GetEventsOfWeek(BDate date)
 {
 	BList* events = new BList();
 	date.AddDays(-date.DayOfWeek()+1);

--- a/src/db/SQLiteManager.h
+++ b/src/db/SQLiteManager.h
@@ -30,7 +30,7 @@ public:
 
 		Event*		GetEvent(const char* id);
 		BList*		GetEventsOfDay(BDate& date);
-		BList*		GetEventsOfWeek(BDate& date);
+		BList*		GetEventsOfWeek(BDate date);
 		BList*		GetEventsToNotify(BDateTime dateTime);
 		bool		RemoveEvent(Event* event);
 		bool		RemoveCancelledEvents();


### PR DESCRIPTION
Fixes #48: The event list does not display current events in certain cases.  This happens when switching between the "Today", "Day", and "Week" event list view.  These changes address that issue by:
1) Properly setting the mode before switching to the day view
2) Preventing the date from inadvertently being modified by calls to `SQLiteManager::GetEventsOfWeek`