### PR TITLE
#22: Use a BFS Query-backed DB manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ SRCS = \
 	 src/utils/ResourceLoader.cpp  \
 	 src/model/Category.cpp  \
 	 src/model/Event.cpp \
+	 src/db/QueryDBManager.cpp  \
 	 src/db/SQLiteManager.cpp  \
 	 src/plugin/GoogleCalendar/EventSync.cpp \
 	 src/plugin/GoogleCalendar/EventSyncWindow.cpp \

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -49,9 +49,6 @@ App::App()
 	fPreferences->Load(fPreferencesFile.Path());
 	fPreferences->fSettingsPath = settingsPath;
 
-	MainWindow::SetPreferences(fPreferences);
-	EventWindow::SetPreferences(fPreferences);
-
 	fMainWindow = new MainWindow();
 	fMainWindow->Show();
 }
@@ -83,6 +80,13 @@ App::QuitRequested()
 	if (fMainWindow->Lock())
 		fMainWindow->Quit();
 	return true;
+}
+
+
+Preferences*
+App::GetPreferences()
+{
+	return fPreferences;
 }
 
 
@@ -120,7 +124,6 @@ App::MessageReceived(BMessage* message)
 		{
 			if (fCategoryWindow == NULL) {
 				fCategoryWindow = new CategoryWindow();
-				fCategoryWindow->SetPreferences(fPreferences);
 				fCategoryWindow->Show();
 			}
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -120,6 +120,7 @@ App::MessageReceived(BMessage* message)
 		{
 			if (fCategoryWindow == NULL) {
 				fCategoryWindow = new CategoryWindow();
+				fCategoryWindow->SetPreferences(fPreferences);
 				fCategoryWindow->Show();
 			}
 

--- a/src/App.h
+++ b/src/App.h
@@ -29,6 +29,7 @@ public:
 
 	void			AboutRequested();
 	bool			QuitRequested();
+	Preferences*	GetPreferences();
 	void			MessageReceived(BMessage* message);
 	MainWindow*		mainWindow();
 	CategoryWindow*		categoryWindow();

--- a/src/App.h
+++ b/src/App.h
@@ -27,10 +27,13 @@ public:
 				App();
 				~App();
 
+	void			ArgvReceived(int32 argc, char** argv);
+	void			MessageReceived(BMessage* message);
+	void			RefsReceived(BMessage* message);
+
 	void			AboutRequested();
 	bool			QuitRequested();
 	Preferences*	GetPreferences();
-	void			MessageReceived(BMessage* message);
 	MainWindow*		mainWindow();
 	CategoryWindow*		categoryWindow();
 

--- a/src/CalendarView.cpp
+++ b/src/CalendarView.cpp
@@ -9,7 +9,7 @@
 #include <DateFormat.h>
 #include <stdlib.h>
 
-#include "SQLiteManager.h"
+#include "QueryDBManager.h"
 
 
 CalendarView::CalendarView(BRect frame, const char* name,
@@ -44,7 +44,7 @@ CalendarView::CalendarView (const char* name, uint32 flags)
 void
 CalendarView::_Init ()
 {
-	fDBManager = new SQLiteManager();
+	fDBManager = new QueryDBManager();
 }
 
 

--- a/src/CalendarView.h
+++ b/src/CalendarView.h
@@ -10,7 +10,7 @@
 #include <View.h>
 
 #include "DateHeaderView.h"
-#include "SQLiteManager.h"
+#include "QueryDBManager.h"
 
 
 namespace BPrivate {
@@ -30,7 +30,7 @@ public:
 		void			DrawDay(BView*, BRect, const char*, bool, bool, bool, bool);
 private:
 		void			_Init();
-		SQLiteManager*		fDBManager;
+		QueryDBManager*	fDBManager;
 };
 
 #endif

--- a/src/CategoryEditWindow.cpp
+++ b/src/CategoryEditWindow.cpp
@@ -22,6 +22,7 @@
 #include "CategoryWindow.h"
 #include "ColorPreview.h"
 #include "MainWindow.h"
+#include "Preferences.h"
 #include "QueryDBManager.h"
 
 #undef B_TRANSLATION_CONTEXT
@@ -105,6 +106,13 @@ CategoryEditWindow::SetCategory(Category* category)
 
 
 void
+CategoryEditWindow::SetPreferences(Preferences* preferences)
+{
+	fPreferences = preferences;
+}
+
+
+void
 CategoryEditWindow::_InitInterface()
 {
 	fMainView = new BView("MainView", B_WILL_DRAW);
@@ -172,7 +180,7 @@ CategoryEditWindow::_CategoryModified()
 void
 CategoryEditWindow::_OnDeletePressed()
 {
-	if (BString(fCategoryText->Text()) == BString(B_TRANSLATE("Default"))) {
+	if (BString(fCategoryText->Text()) == fPreferences->fDefaultCategory) {
 		BAlert* alert  = new BAlert(B_TRANSLATE("Error"),
 			B_TRANSLATE("You cannot delete the default category."),
 			NULL, B_TRANSLATE("OK"),NULL, B_WIDTH_AS_USUAL, B_WARNING_ALERT);

--- a/src/CategoryEditWindow.cpp
+++ b/src/CategoryEditWindow.cpp
@@ -106,13 +106,6 @@ CategoryEditWindow::SetCategory(Category* category)
 
 
 void
-CategoryEditWindow::SetPreferences(Preferences* preferences)
-{
-	fPreferences = preferences;
-}
-
-
-void
 CategoryEditWindow::_InitInterface()
 {
 	fMainView = new BView("MainView", B_WILL_DRAW);
@@ -180,7 +173,9 @@ CategoryEditWindow::_CategoryModified()
 void
 CategoryEditWindow::_OnDeletePressed()
 {
-	if (BString(fCategoryText->Text()) == fPreferences->fDefaultCategory) {
+	BString defaultCat = ((App*)be_app)->GetPreferences()->fDefaultCategory;
+
+	if (BString(fCategoryText->Text()) == defaultCat) {
 		BAlert* alert  = new BAlert(B_TRANSLATE("Error"),
 			B_TRANSLATE("You cannot delete the default category."),
 			NULL, B_TRANSLATE("OK"),NULL, B_WIDTH_AS_USUAL, B_WARNING_ALERT);

--- a/src/CategoryEditWindow.cpp
+++ b/src/CategoryEditWindow.cpp
@@ -22,7 +22,7 @@
 #include "CategoryWindow.h"
 #include "ColorPreview.h"
 #include "MainWindow.h"
-#include "SQLiteManager.h"
+#include "QueryDBManager.h"
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "CategoryEditWindow"

--- a/src/CategoryEditWindow.h
+++ b/src/CategoryEditWindow.h
@@ -15,7 +15,6 @@ class BTextControl;
 class BView;
 class Category;
 class ColorPreview;
-class Preferences;
 
 
 const uint32 kCategoryEditQuitting = 'kceq';
@@ -32,7 +31,6 @@ public:
 	virtual bool		QuitRequested();
 
 	void			SetCategory(Category* category);
-	void			SetPreferences(Preferences* preferences);
 
 private:
 	void			_InitInterface();
@@ -55,8 +53,6 @@ private:
 	BButton*		fDeleteButton;
 
 	Category*		fCategory;
-	Preferences*	fPreferences;
-
 };
 
 

--- a/src/CategoryEditWindow.h
+++ b/src/CategoryEditWindow.h
@@ -15,6 +15,7 @@ class BTextControl;
 class BView;
 class Category;
 class ColorPreview;
+class Preferences;
 
 
 const uint32 kCategoryEditQuitting = 'kceq';
@@ -31,6 +32,7 @@ public:
 	virtual bool		QuitRequested();
 
 	void			SetCategory(Category* category);
+	void			SetPreferences(Preferences* preferences);
 
 private:
 	void			_InitInterface();
@@ -53,6 +55,7 @@ private:
 	BButton*		fDeleteButton;
 
 	Category*		fCategory;
+	Preferences*	fPreferences;
 
 };
 

--- a/src/CategoryWindow.cpp
+++ b/src/CategoryWindow.cpp
@@ -17,7 +17,7 @@
 #include "Category.h"
 #include "CategoryEditWindow.h"
 #include "CategoryListItem.h"
-#include "SQLiteManager.h"
+#include "QueryDBManager.h"
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "CategoryWindow"
@@ -113,7 +113,7 @@ CategoryWindow::LoadCategories()
 }
 
 
-SQLiteManager*
+QueryDBManager*
 CategoryWindow::GetDBManager()
 {
 	return fDBManager;
@@ -133,7 +133,7 @@ CategoryWindow::_InitInterface()
 		B_WILL_DRAW, false, true);
 	fCategoryScroll->SetExplicitMinSize(BSize(260, 220));
 
-	fDBManager = new SQLiteManager();
+	fDBManager = new QueryDBManager();
 	fCategoryList = new BList();
 	LoadCategories();
 

--- a/src/CategoryWindow.cpp
+++ b/src/CategoryWindow.cpp
@@ -121,13 +121,6 @@ CategoryWindow::GetDBManager()
 
 
 void
-CategoryWindow::SetPreferences(Preferences* preferences)
-{
-	fPreferences = preferences;
-}
-
-
-void
 CategoryWindow::_InitInterface()
 {
 	fMainView = new BView("MainView", B_WILL_DRAW);
@@ -174,7 +167,6 @@ CategoryWindow::_OpenCategoryWindow(Category* category)
 {
 	if (fCategoryEditWindow == NULL) {
 		fCategoryEditWindow = new CategoryEditWindow();
-		fCategoryEditWindow->SetPreferences(fPreferences);
 		fCategoryEditWindow->SetCategory(category);
 		fCategoryEditWindow->Show();
 	}

--- a/src/CategoryWindow.cpp
+++ b/src/CategoryWindow.cpp
@@ -121,6 +121,13 @@ CategoryWindow::GetDBManager()
 
 
 void
+CategoryWindow::SetPreferences(Preferences* preferences)
+{
+	fPreferences = preferences;
+}
+
+
+void
 CategoryWindow::_InitInterface()
 {
 	fMainView = new BView("MainView", B_WILL_DRAW);
@@ -167,6 +174,7 @@ CategoryWindow::_OpenCategoryWindow(Category* category)
 {
 	if (fCategoryEditWindow == NULL) {
 		fCategoryEditWindow = new CategoryEditWindow();
+		fCategoryEditWindow->SetPreferences(fPreferences);
 		fCategoryEditWindow->SetCategory(category);
 		fCategoryEditWindow->Show();
 	}

--- a/src/CategoryWindow.h
+++ b/src/CategoryWindow.h
@@ -13,7 +13,7 @@ class BScrollView;
 class BView;
 class Category;
 class CategoryEditWindow;
-class SQLiteManager;
+class QueryDBManager;
 
 
 const uint32 kCategoryWindowQuitting = 'kcwq';
@@ -28,7 +28,7 @@ public:
 	virtual bool		QuitRequested();
 
 	void			LoadCategories();
-	SQLiteManager*		GetDBManager();
+	QueryDBManager*	GetDBManager();
 
 private:
 	void			_InitInterface();
@@ -46,7 +46,7 @@ private:
 	CategoryEditWindow*	fCategoryEditWindow;
 
 	BList*			fCategoryList;
-	SQLiteManager*  	fDBManager;
+	QueryDBManager*	fDBManager;
 
 };
 

--- a/src/CategoryWindow.h
+++ b/src/CategoryWindow.h
@@ -13,6 +13,7 @@ class BScrollView;
 class BView;
 class Category;
 class CategoryEditWindow;
+class Preferences;
 class QueryDBManager;
 
 
@@ -30,6 +31,8 @@ public:
 	void			LoadCategories();
 	QueryDBManager*	GetDBManager();
 
+	void			SetPreferences(Preferences* preferences);
+
 private:
 	void			_InitInterface();
 	void			_OpenCategoryWindow(Category* category);
@@ -46,6 +49,7 @@ private:
 	CategoryEditWindow*	fCategoryEditWindow;
 
 	BList*			fCategoryList;
+	Preferences*	fPreferences;
 	QueryDBManager*	fDBManager;
 
 };

--- a/src/CategoryWindow.h
+++ b/src/CategoryWindow.h
@@ -13,7 +13,6 @@ class BScrollView;
 class BView;
 class Category;
 class CategoryEditWindow;
-class Preferences;
 class QueryDBManager;
 
 
@@ -31,8 +30,6 @@ public:
 	void			LoadCategories();
 	QueryDBManager*	GetDBManager();
 
-	void			SetPreferences(Preferences* preferences);
-
 private:
 	void			_InitInterface();
 	void			_OpenCategoryWindow(Category* category);
@@ -49,7 +46,6 @@ private:
 	CategoryEditWindow*	fCategoryEditWindow;
 
 	BList*			fCategoryList;
-	Preferences*	fPreferences;
 	QueryDBManager*	fDBManager;
 
 };

--- a/src/DayView.cpp
+++ b/src/DayView.cpp
@@ -19,7 +19,7 @@
 #include "Event.h"
 #include "EventListItem.h"
 #include "EventListView.h"
-#include "SQLiteManager.h"
+#include "QueryDBManager.h"
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "DayView"
@@ -39,7 +39,7 @@ DayView::DayView(const BDate& date)
 		B_WILL_DRAW, false, true);
 	fEventScroll->SetExplicitMinSize(BSize(260, 260));
 
-	fDBManager = new SQLiteManager();
+	fDBManager = new QueryDBManager();
 	LoadEvents();
 
 	BLayoutBuilder::Group<>(this, B_VERTICAL, 0)

--- a/src/DayView.h
+++ b/src/DayView.h
@@ -13,7 +13,7 @@ class BScrollView;
 class BList;
 class Event;
 class EventListView;
-class SQLiteManager;
+class QueryDBManager;
 
 
 const uint32 kEditEventMessage = 'ksem';
@@ -41,10 +41,10 @@ private:
 		static const uint32 kInvokationMessage = 1000;
 
 		BList*			fEventList;
-		EventListView*		fEventListView;
-		BScrollView*		fEventScroll;
+		EventListView*	fEventListView;
+		BScrollView*	fEventScroll;
 		BDate			fDate;
-		SQLiteManager*		fDBManager;
+		QueryDBManager*	fDBManager;
 		
 		int32 mode;
 

--- a/src/EventWindow.cpp
+++ b/src/EventWindow.cpp
@@ -46,18 +46,19 @@
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "EventWindow"
 
-Preferences* EventWindow::fPreferences = NULL;
-
 
 EventWindow::EventWindow()
 	:
-	BWindow(fPreferences->fEventWindowRect, B_TRANSLATE("Event manager"),
+	BWindow(((App*)be_app)->GetPreferences()->fEventWindowRect,
+			B_TRANSLATE("Event manager"),
 			B_TITLED_WINDOW, B_AUTO_UPDATE_SIZE_LIMITS)
 {
 	_InitInterface();
 
-	if (fPreferences->fEventWindowRect == BRect()) {
-		fPreferences->fEventWindowRect = Frame();
+	Preferences* preferences = ((App*)be_app)->GetPreferences();
+
+	if (preferences->fEventWindowRect == BRect()) {
+		preferences->fEventWindowRect = Frame();
 		CenterOnScreen();
 	}
 
@@ -133,7 +134,7 @@ EventWindow::MessageReceived(BMessage* message)
 void
 EventWindow::FrameMoved(BPoint newPosition)
 {
-	fPreferences->fEventWindowRect.OffsetTo(newPosition);
+	((App*)be_app)->GetPreferences()->fEventWindowRect.OffsetTo(newPosition);
 }
 
 
@@ -263,13 +264,6 @@ EventWindow::QuitRequested()
 {
 	((App*)be_app)->mainWindow()->PostMessage(kEventWindowQuitting);
 	return true;
-}
-
-
-void
-EventWindow::SetPreferences(Preferences* preferences)
-{
-	fPreferences = preferences;
 }
 
 

--- a/src/EventWindow.cpp
+++ b/src/EventWindow.cpp
@@ -41,7 +41,7 @@
 #include "Event.h"
 #include "MainWindow.h"
 #include "Preferences.h"
-#include "SQLiteManager.h"
+#include "QueryDBManager.h"
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "EventWindow"
@@ -453,7 +453,7 @@ EventWindow::_InitInterface()
 	fStartCalButton->SetExplicitMinSize(BSize(height * 2, height));
 	fEndCalButton->SetExplicitMinSize(BSize(height * 2, height));
 
-	fDBManager = new SQLiteManager();
+	fDBManager = new QueryDBManager();
 
 	fCategoryList = fDBManager->GetAllCategories();
 

--- a/src/EventWindow.h
+++ b/src/EventWindow.h
@@ -26,7 +26,7 @@ class BView;
 class Category;
 class Event;
 class Preferences;
-class SQLiteManager;
+class QueryDBManager;
 
 
 static const uint32 kEventWindowQuitting = 'kewq';
@@ -121,7 +121,7 @@ private:
 	Event*			fEvent;
 	BList*			fCategoryList;
 
-	SQLiteManager*		fDBManager;
+	QueryDBManager*	fDBManager;
 };
 
 #endif

--- a/src/EventWindow.h
+++ b/src/EventWindow.h
@@ -48,8 +48,6 @@ public:
 	void			SetStartDate(BDate& date);
 	void			SetEndDate(BDate& date);
 
-	static void		SetPreferences(Preferences* preferences);
-
 	void			OnCheckBoxToggle();
 	void			OnSaveClick();
 	void			OnDeleteClick();
@@ -72,8 +70,6 @@ private:
 	static const uint32	kAllDayPressed	= 1003;
 	static const uint32	kOptEveryMonth	= 1004;
 	static const uint32	kOptEveryYear	= 1005;
-
-	static Preferences*	fPreferences;
 
 	BTextControl*		fTextName;
 	BTextControl*		fTextPlace;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -14,6 +14,7 @@
 #include <MenuBar.h>
 #include <ToolBar.h>
 
+#include "App.h"
 #include "CategoryEditWindow.h"
 #include "DayView.h"
 #include "Event.h"
@@ -33,12 +34,12 @@ using BPrivate::BToolBar;
 #define B_TRANSLATION_CONTEXT "MainWindow"
 
 extern int32 NotificationLoop(void* data);
-Preferences* MainWindow::fPreferences = NULL;
 
 
 MainWindow::MainWindow()
 	:
-	BWindow(fPreferences->fMainWindowRect, B_TRANSLATE_SYSTEM_NAME("Calendar"), B_TITLED_WINDOW,
+	BWindow(((App*)be_app)->GetPreferences()->fMainWindowRect,
+		B_TRANSLATE_SYSTEM_NAME("Calendar"), B_TITLED_WINDOW,
 		B_AUTO_UPDATE_SIZE_LIMITS),
 	fEventWindow(NULL)
 {
@@ -46,7 +47,7 @@ MainWindow::MainWindow()
 
 	_InitInterface();
 
-	if (fPreferences->fMainWindowRect == BRect()) {
+	if (((App*)be_app)->GetPreferences()->fMainWindowRect == BRect()) {
 		ResizeTo(640, 360);
 		CenterOnScreen();
 	}
@@ -143,8 +144,10 @@ MainWindow::MessageReceived(BMessage* message)
 			break;
 
 		case B_LOCALE_CHANGED:
-		{	fSidePanelView->MessageReceived(message);
-			fSidePanelView->SetStartOfWeek(fPreferences->fStartOfWeekOffset);
+		{
+			Preferences* preferences = ((App*)be_app)->GetPreferences();
+			fSidePanelView->MessageReceived(message);
+			fSidePanelView->SetStartOfWeek(preferences->fStartOfWeekOffset);
 			_UpdateDayView();
 			break;
 		}
@@ -182,13 +185,6 @@ MainWindow::MessageReceived(BMessage* message)
 			BWindow::MessageReceived(message);
 			break;
 	}
-}
-
-
-void
-MainWindow::SetPreferences(Preferences* preferences)
-{
-	fPreferences = preferences;
 }
 
 
@@ -315,13 +311,15 @@ MainWindow::_SetEventListPopUpEnabled(bool state)
 void
 MainWindow::_SyncWithPreferences()
 {
-	if (fPreferences != NULL) {
-		if(fPreferences->fHeaderVisible == true)
+	Preferences* preferences = ((App*)be_app)->GetPreferences();
+
+	if (preferences != NULL) {
+		if(preferences->fHeaderVisible == true)
 			fSidePanelView->ShowWeekHeader(true);
 		else
 			fSidePanelView->ShowWeekHeader(false);
 
-		fSidePanelView->SetStartOfWeek(fPreferences->fStartOfWeekOffset);
+		fSidePanelView->SetStartOfWeek(preferences->fStartOfWeekOffset);
 	}
 }
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -37,8 +37,6 @@ public:
 	virtual void		MessageReceived(BMessage* message);
 	virtual bool		QuitRequested();
 
-	static void		SetPreferences(Preferences* preferences);
-
 	void			StartNotificationThread();
 	void			StopNotificationThread();
 private:
@@ -57,8 +55,6 @@ private:
 	static const int 	kWeekView		= 1006;
 	static const int 	kAgendaView		= 1007;
 
-
-	static Preferences*	fPreferences;
 
 	MainView*		fMainView;
 	EventWindow*		fEventWindow;

--- a/src/NotificationLoop.cpp
+++ b/src/NotificationLoop.cpp
@@ -12,7 +12,7 @@
 #include "App.h"
 #include "Event.h"
 #include "ResourceLoader.h"
-#include "SQLiteManager.h"
+#include "QueryDBManager.h"
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "NotificationLoop"
@@ -20,7 +20,7 @@
 int32
 NotificationLoop(void* data)
 {
-	SQLiteManager dbManager;
+	QueryDBManager dbManager;
 	BString notificationContent;
 	BString startTime;
 	BList* events;

--- a/src/PreferenceWindow.h
+++ b/src/PreferenceWindow.h
@@ -15,6 +15,7 @@ class BMenuField;
 class BStringView;
 class BView;
 class Preferences;
+class QueryDBManager;
 
 
 const uint32 kPreferenceWindowQuitting	= 'kpwq';
@@ -34,24 +35,32 @@ private:
 		void				_SyncPreferences(Preferences* preferences);
 		void				_PreferencesModified();
 
-		static const int		kStartOfWeekChangeMessage 	= 1000;
-		static const int 		kShowWeekChangeMessage		= 1001;
-		static const int		kApplyPreferencesMessage	= 1002;
-		static const int		kRevertPreferencesMessage	= 1003;
+		static const int		kStartOfWeekChangeMessage 		= 1000;
+		static const int 		kShowWeekChangeMessage			= 1001;
+		static const int		kApplyPreferencesMessage		= 1002;
+		static const int		kRevertPreferencesMessage		= 1003;
+		static const int		kDefaultCategoryChangeMessage 	= 1004;
 
 		BView*				fMainView;
 		BCheckBox*			fWeekNumberHeaderCB;
-		BStringView*			fPrefCategoryLabel;
+		BStringView*			fWeekCategoryLabel;
+		BStringView*			fOrgCategoryLabel;
 		BStringView*			fStartOfWeekLabel;
+		BStringView*			fDefaultCatLabel;
 		BPopUpMenu*			fDayOfWeekMenu;
+		BPopUpMenu*			fDefaultCatMenu;
 		BMenuField*			fDayOfWeekMenuField;
+		BMenuField*			fDefaultCatMenuField;
 		BBox*				fWeekPreferencesBox;
+		BBox*				fOrgPreferencesBox;
 		BButton*			fApplyButton;
 		BButton*			fRevertButton;
 
 		Preferences*			fStartPreferences;
 		Preferences*			fCurrentPreferences;
 		Preferences*			fTempPreferences;
+
+		QueryDBManager*		fDBManager;
 };
 
 #endif

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -11,6 +11,7 @@
 #include <Catalog.h>
 #include <File.h>
 #include <Message.h>
+#include <String.h>
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "Preferences"
@@ -65,6 +66,7 @@ Preferences::Load(const char* filename)
 		storage.Unflatten(file);
 	fStartOfWeekOffset = storage.GetInt32("startOfWeekOffset", 0);
 	fHeaderVisible = storage.GetBool("headerVisible", false);
+	fDefaultCategory = storage.GetString("defaultCategory", B_TRANSLATE("Default"));
 	fMainWindowRect = storage.GetRect("mainWindowRect", BRect());
 	fEventWindowRect = storage.GetRect("eventWindowRect", BRect());
 
@@ -120,6 +122,7 @@ Preferences::Save(const char* filename)
 	BMessage storage;
 	storage.AddInt32("startOfWeekOffset", fStartOfWeekOffset);
 	storage.AddBool("headerVisible", fHeaderVisible);
+	storage.AddString("defaultCategory", fDefaultCategory);
 	storage.AddRect("mainWindowRect", fMainWindowRect);
 	storage.AddRect("eventWindowRect", fEventWindowRect);
 
@@ -135,6 +138,7 @@ Preferences::operator =(const Preferences& p)
 	fSettingsPath = p.fSettingsPath;
 	fStartOfWeekOffset = p.fStartOfWeekOffset;
 	fHeaderVisible = p.fHeaderVisible;
+	fDefaultCategory = p.fDefaultCategory;
 	fMainWindowRect = p.fMainWindowRect;
 	fEventWindowRect = p.fEventWindowRect;
 

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -11,6 +11,7 @@
 #include <string>
 
 #include <Path.h>
+#include <String.h>
 
 
 class Preferences {
@@ -24,6 +25,7 @@ public:
 
 	int32					fStartOfWeekOffset;
 	bool					fHeaderVisible;
+	BString					fDefaultCategory;
 	BRect					fMainWindowRect;
 	BRect					fEventWindowRect;
 };

--- a/src/calendar.rdef
+++ b/src/calendar.rdef
@@ -21,6 +21,11 @@ resource app_version {
 	long_info  = "A native Calendar Application for Haiku."
 };
 
+resource file_types message {
+	"types" = "application/x-calendar-category",
+	"types" = "application/x-calendar-event"
+};
+
 resource(1, "ADD_EVENT") #'VICN' array {
 	$"6E6369660404006603800000020006020000003C6000C000000000004C000048"
 	$"A00000FFABABFFD90000020016020000003B3FFFC000000000004C000048A000"

--- a/src/db/QueryDBManager.cpp
+++ b/src/db/QueryDBManager.cpp
@@ -98,9 +98,9 @@ QueryDBManager::_Initialise()
 	// Create default categories if need be
 	if (GetAllCategories()->CountItems() == 0) {
 		Category* defaultCategory =
-			new Category(B_TRANSLATE("Default"), BString("1E90FF"), "1f1e4ffd-527d-4796-953f-df2e2c600a09");
+			new Category(B_TRANSLATE("Default"), BString("1E90FF"));
 		Category* birthdayCategory =
-			new Category(B_TRANSLATE("Birthday"), BString("C25656"), "47c30a47-7c79-4d45-883a-8f45b9ddcff4");
+			new Category(B_TRANSLATE("Birthday"), BString("C25656"));
 		AddCategory(defaultCategory);
 		AddCategory(birthdayCategory);
 	}

--- a/src/db/QueryDBManager.cpp
+++ b/src/db/QueryDBManager.cpp
@@ -219,6 +219,14 @@ Event*
 QueryDBManager::GetEvent(const char* name, time_t startTime)
 {
 	entry_ref ref = _GetEventRef(name, startTime);
+
+	return GetEvent(ref);
+}
+
+
+Event*
+QueryDBManager::GetEvent(entry_ref ref)
+{
 	BFile evFile = BFile(&ref, B_READ_ONLY);
 	if (evFile.InitCheck() != B_OK)
 		return NULL;
@@ -359,6 +367,14 @@ Category*
 QueryDBManager::GetCategory(const char* name)
 {
 	entry_ref ref = _GetCategoryRef(name);
+
+	return GetCategory(ref);
+}
+
+
+Category*
+QueryDBManager::GetCategory(entry_ref ref)
+{
 	BFile catFile = BFile(&ref, B_READ_ONLY);
 
 	if (catFile.InitCheck() != B_OK)
@@ -814,6 +830,7 @@ QueryDBManager::_CategoryMimetype()
 
 	mime.SetShortDescription("Calendar Category");
 	mime.SetLongDescription("Category of calendar events");
+	mime.SetPreferredApp("application/x-vnd.calendar");
 
 	_AddAttribute(info, "Category:Name",	"Name", B_STRING_TYPE, true, 300);
 	_AddAttribute(info, "Category:Color",	"Color", B_RGB_COLOR_TYPE, false, 100);
@@ -835,6 +852,7 @@ QueryDBManager::_EventMimetype()
 
 	mime.SetShortDescription("Calendar Event");
 	mime.SetLongDescription("Generic calendar event");
+	mime.SetPreferredApp("application/x-vnd.calendar");
 
 	_AddAttribute(info, "Event:Name",	"Name",		B_STRING_TYPE, true, 300);
 	_AddAttribute(info, "Event:Start",	"Start",	B_TIME_TYPE, true, 150);

--- a/src/db/QueryDBManager.cpp
+++ b/src/db/QueryDBManager.cpp
@@ -547,11 +547,13 @@ Category*
 QueryDBManager::_FileToCategory(BFile* file)
 {
 	BString name = BString();
-	BString color = BString();
 	BString idStr = BString();
 	file->ReadAttrString("Category:Name", &name);
-	file->ReadAttrString("Category:Color", &color);
 	file->ReadAttrString("Calendar:ID", &idStr);
+
+	rgb_color color = {28, 144, 255};
+	file->ReadAttr("Category:Color", B_RGB_COLOR_TYPE, 0, &color,
+		sizeof(rgb_color));
 
 	return new Category(name, color, idStr.String());
 }
@@ -618,9 +620,9 @@ QueryDBManager::_CategoryToFile(Category* category, BFile* file)
 	file->WriteAttr("Calendar:ID", B_STRING_TYPE, 0, id.String(),
 						id.CountChars() + 1);
 
-	BString color = category->GetHexColor();
-	file->WriteAttr("Category:Color", B_STRING_TYPE, 0, color.String(),
-						color.CountChars() + 1);
+	rgb_color color = category->GetColor();
+	file->WriteAttr("Category:Color", B_RGB_COLOR_TYPE, 0, &color,
+		sizeof(rgb_color));
 
 	return true;
 }
@@ -814,7 +816,7 @@ QueryDBManager::_CategoryMimetype()
 	mime.SetLongDescription("Category of calendar events");
 
 	_AddAttribute(info, "Category:Name",	"Name", B_STRING_TYPE, true, 300);
-	_AddAttribute(info, "Category:Color",	"Color", B_STRING_TYPE, true, 100);
+	_AddAttribute(info, "Category:Color",	"Color", B_RGB_COLOR_TYPE, false, 100);
 	_AddAttribute(info, "Calendar:ID",		"ID", B_STRING_TYPE, true, 100);
 
 	return mime.SetAttrInfo( &info );

--- a/src/db/QueryDBManager.cpp
+++ b/src/db/QueryDBManager.cpp
@@ -23,6 +23,7 @@
 
 #include "Category.h"
 #include "Event.h"
+#include "Preferences.h"
 #include "SQLiteManager.h"
 #include "QueryDBManager.h"
 
@@ -53,6 +54,7 @@ QueryDBManager::_Initialise()
 	BPath eventPath;
 	BPath cancelledPath;
 	BPath categoryPath;
+	BPath settingsPath;
 	BPath sqlPath;
 
 	find_directory(B_USER_SETTINGS_DIRECTORY, &rootPath);
@@ -84,6 +86,12 @@ QueryDBManager::_Initialise()
 	if (fCategoryDir->InitCheck() == B_ENTRY_NOT_FOUND) {
 		fCategoryDir->CreateDirectory(categoryPath.Path(), fCategoryDir);
 	}
+
+	// Settings
+	settingsPath = BPath(rootPath);
+	settingsPath.Append("settings");
+	fPreferences = new Preferences();
+	fPreferences->Load(settingsPath.Path());
 
 	BVolumeRoster volRoster;
 	volRoster.GetBootVolume(&fQueryVolume);
@@ -365,7 +373,7 @@ QueryDBManager::GetAllCategories()
 		catFile = new BFile(&ref, B_READ_ONLY);
 		category = _FileToCategory(catFile);
 
-		if (category->GetName() == BString(B_TRANSLATE("Default")))
+		if (category->GetName() == fPreferences->fDefaultCategory)
 			categories->AddItem(category, 0);
 		else if (!category->GetName().IsEmpty())
 			categories->AddItem(category);

--- a/src/db/QueryDBManager.cpp
+++ b/src/db/QueryDBManager.cpp
@@ -323,6 +323,12 @@ QueryDBManager::AddCategory(Category* category)
 	if (GetCategory(category->GetName()) != NULL)
 		return false;
 
+	BString color = category->GetHexColor();
+	BList* categories = GetAllCategories();
+	for (int i = 0; i < categories->CountItems(); i++)
+		if (color == ((Category*)categories->ItemAt(i))->GetHexColor())
+			return false;
+
 	BFile catFile = BFile();
 	status_t result =
 		_CreateUniqueFile(fCategoryDir, category->GetName(), &catFile);
@@ -866,7 +872,6 @@ QueryDBManager::_AddIndices()
 		fs_create_index(device, "Event:Status",		B_STRING_TYPE, 0);
 		fs_create_index(device, "Calendar:ID",		B_STRING_TYPE, 0);
 		fs_create_index(device, "Category:Name",	B_STRING_TYPE, 0);
-		fs_create_index(device, "Category:Color",	B_STRING_TYPE, 0);
 	}
 }
 

--- a/src/db/QueryDBManager.cpp
+++ b/src/db/QueryDBManager.cpp
@@ -1,0 +1,877 @@
+/*
+ * All rights reserved. Distributed under the terms of the MIT License.
+ */
+
+#include <stdio.h>
+#include <time.h>
+
+#include <Alert.h>
+#include <Catalog.h>
+#include <Directory.h>
+#include <Entry.h>
+#include <File.h>
+#include <FindDirectory.h>
+#include <fs_index.h>
+#include <fs_info.h>
+#include <List.h>
+#include <Message.h>
+#include <MimeType.h>
+#include <Query.h>
+#include <String.h>
+#include <StringList.h>
+#include <VolumeRoster.h>
+
+#include "Category.h"
+#include "Event.h"
+#include "QueryDBManager.h"
+
+#undef B_TRANSLATION_CONTEXT
+#define B_TRANSLATION_CONTEXT "QueryDBManager"
+
+const char* kEventDir		= "events";
+const char* kCancelledDir	= "cancelled";
+const char* kCategoryDir	= "categories";
+
+
+QueryDBManager::QueryDBManager()
+{
+	_Initialise();
+}
+
+
+QueryDBManager::~QueryDBManager()
+{
+	delete(fEventDir, fCategoryDir);
+}
+
+
+void
+QueryDBManager::_Initialise()
+{
+	BPath rootPath;
+	BPath eventPath;
+	BPath cancelledPath;
+	BPath categoryPath;
+
+	find_directory(B_USER_SETTINGS_DIRECTORY, &rootPath);
+	rootPath.Append(kDirectoryName);
+
+	// event directory
+	eventPath = BPath(rootPath);
+	eventPath.Append(kEventDir);
+	BDirectory* eventDir = new BDirectory(eventPath.Path());
+	fEventDir = eventDir;
+	if (fEventDir->InitCheck() == B_ENTRY_NOT_FOUND) {
+		fEventDir->CreateDirectory(eventPath.Path(), fEventDir);
+	}
+
+	// cancelled directory
+	cancelledPath = BPath(rootPath);
+	cancelledPath.Append(kCancelledDir);
+	BDirectory* cancelledDir = new BDirectory(cancelledPath.Path());
+	fCancelledDir = cancelledDir;
+	if (fCancelledDir->InitCheck() == B_ENTRY_NOT_FOUND) {
+		fCancelledDir->CreateDirectory(cancelledPath.Path(), fCancelledDir);
+	}
+
+	// category directory
+	categoryPath = BPath(rootPath);
+	categoryPath.Append(kCategoryDir);
+	BDirectory* categoryDir = new BDirectory(categoryPath.Path());
+	fCategoryDir = categoryDir;
+	if (fCategoryDir->InitCheck() == B_ENTRY_NOT_FOUND) {
+		fCategoryDir->CreateDirectory(categoryPath.Path(), fCategoryDir);
+	}
+
+	BVolumeRoster volRoster;
+	volRoster.GetBootVolume(&fQueryVolume);
+
+	_CategoryMimetype();
+	_EventMimetype();
+	_AddIndices();
+
+	Category* defaultCategory =
+		new Category(B_TRANSLATE("Default"), BString("1E90FF"), "1f1e4ffd-527d-4796-953f-df2e2c600a09");
+	Category* birthdayCategory =
+		new Category(B_TRANSLATE("Birthday"), BString("C25656"), "47c30a47-7c79-4d45-883a-8f45b9ddcff4");
+
+	AddCategory(defaultCategory);
+	AddCategory(birthdayCategory);
+}
+
+
+bool
+QueryDBManager::AddEvent(Event* event)
+{
+	if (BString(event->GetName()).CountChars() < 3)
+		return false;
+	if (GetEvent(event->GetName(), event->GetStartDateTime()) != NULL)
+		return false;
+
+	BFile* evFile = new BFile();
+	status_t result = _CreateUniqueFile(fEventDir, event->GetName(), evFile);
+
+	if (_EventStatusSwitch(result) != B_OK)
+		return false;
+
+	return _EventToFile(event, evFile);
+}
+
+
+bool
+QueryDBManager::UpdateEvent(Event* event, Event* newEvent)
+{
+	entry_ref ref = _GetEventRef(event->GetName(), event->GetStartDateTime());
+	BFile* evFile = new BFile(&ref, B_READ_WRITE);
+	if (_EventStatusSwitch(evFile->InitCheck()) != B_OK)
+		return NULL;
+
+	return _EventToFile(newEvent, evFile);
+}
+
+
+bool
+QueryDBManager::UpdateNotifiedEvent(const char* id)
+{
+	BFile* evFile = new BFile();
+	_GetItemOfId(id, evFile);
+	if (_EventStatusSwitch(evFile->InitCheck()) != B_OK)
+		return NULL;
+
+	Event* event = _FileToEvent(evFile);
+
+	event->SetNotified(true);
+	return _EventToFile(event, evFile);
+}
+
+
+bool
+QueryDBManager::RemoveEvent(Event* event)
+{
+	entry_ref ref = _GetEventRef(event->GetName(), event->GetStartDateTime());
+	return RemoveEvent(ref);
+}
+
+
+bool
+QueryDBManager::RemoveEvent(entry_ref eventRef)
+{
+	status_t result = BEntry(&eventRef).Remove();
+	if (_EventStatusSwitch(result) == B_OK)
+		return true;
+	return false;
+}
+
+
+bool
+QueryDBManager::RemoveCancelledEvents()
+{
+	BQuery* query = new BQuery();
+	query->SetVolume(&fQueryVolume);
+
+	query->PushAttr("Event:Status");
+	query->PushString("Cancelled");
+	query->PushOp(B_EQ);
+
+	query->Fetch();
+	entry_ref ref;
+
+	BFile* evFile;
+	Event* event;
+
+	while (query->GetNextRef(&ref) == B_OK) {
+		RemoveEvent(ref);
+	}
+
+	return true;
+}
+
+
+Event*
+QueryDBManager::GetEvent(const char* id)
+{
+	BFile* evFile;
+	_GetItemOfId(id, evFile);
+	if (evFile->InitCheck() != B_OK)
+		return NULL;
+
+	return _FileToEvent(evFile);
+}
+
+
+Event*
+QueryDBManager::GetEvent(const char* name, time_t startTime)
+{
+	entry_ref ref = _GetEventRef(name, startTime);
+	BFile* evFile = new BFile(&ref, B_READ_ONLY);
+	if (evFile->InitCheck() != B_OK)
+		return NULL;
+
+	return _FileToEvent(evFile);
+}
+
+
+BList*
+QueryDBManager::GetEventsOfDay(BDate& date)
+{
+	time_t dayStart	= BDateTime(date, BTime(0, 0, 0)).Time_t();
+	time_t dayEnd	= BDateTime(date, BTime(23, 59, 59)).Time_t();
+
+	return _GetEventsOfInterval(dayStart, dayEnd);
+}
+
+
+BList*
+QueryDBManager::GetEventsOfWeek(BDate& date)
+{
+	date.AddDays(-date.DayOfWeek()+1);
+	time_t weekStart = BDateTime(date, BTime(0, 0, 0)).Time_t();
+	date.AddDays(6);
+	time_t weekEnd = BDateTime(date, BTime(23, 59, 59)).Time_t();
+
+	return _GetEventsOfInterval(weekStart, weekEnd);
+}
+
+
+BList*
+QueryDBManager::GetEventsToNotify(BDateTime dateTime)
+{
+	BList* events = new BList();
+	BQuery* query = new BQuery();
+	query->SetVolume(&fQueryVolume);
+
+	time_t time = dateTime.Time_t();
+
+	query->PushAttr("Event:Start");
+	query->PushUInt32(time);
+	query->PushOp(B_LE);
+
+	query->PushAttr("Event:Status");
+	query->PushString("Unnotified");
+	query->PushOp(B_EQ);
+	query->PushOp(B_AND);
+
+	query->Fetch();
+	entry_ref ref;
+
+	BFile* evFile;
+	Event* event;
+
+	while (query->GetNextRef(&ref) == B_OK) {
+		evFile = new BFile(&ref, B_READ_WRITE);
+		event = _FileToEvent(evFile);
+		events->AddItem(event);
+	}
+
+	delete(query);
+	return events;
+}
+
+
+bool
+QueryDBManager::AddCategory(Category* category)
+{
+	if (BString(category->GetName()).CountChars() < 3)
+		return false;
+	if (GetCategory(category->GetName()) != NULL)
+		return false;
+
+	BFile* catFile = new BFile();
+	status_t result =
+		_CreateUniqueFile(fCategoryDir, category->GetName(), catFile);
+
+	if (_CategoryStatusSwitch(result) != B_OK)
+		return false;
+
+	return _CategoryToFile(category, catFile);
+}
+
+
+bool
+QueryDBManager::UpdateCategory(Category* category, Category* newCategory)
+{
+	entry_ref ref = _GetCategoryRef(category->GetName());
+	BFile* catFile = new BFile(&ref, B_READ_WRITE);
+	if (_CategoryStatusSwitch(catFile->InitCheck()) != B_OK)
+		return NULL;
+
+	if (category->GetName() != newCategory->GetName())
+		_ReplaceCategory(category->GetName(), newCategory->GetName());
+
+	return _CategoryToFile(newCategory, catFile);
+}
+
+
+Category*
+QueryDBManager::GetCategory(const char* name)
+{
+	entry_ref ref = _GetCategoryRef(name);
+	BFile* catFile = new BFile(&ref, B_READ_ONLY);
+
+	if (catFile->InitCheck() != B_OK)
+		return NULL;
+
+	return _FileToCategory(catFile);
+}
+
+
+Category*
+QueryDBManager::EnsureCategory(const char* name)
+{
+	Category* category = GetCategory(name);
+
+	if (category == NULL || category->GetName() == NULL) {
+		category = new Category(name, BString("1E90FF"), "");
+		AddCategory(category);
+	}
+
+	return category;
+}
+
+
+BList*
+QueryDBManager::GetAllCategories()
+{
+	BList* categories = new BList();
+	BQuery* query = new BQuery();
+	query->SetVolume(&fQueryVolume);
+
+	query->PushAttr("Category:Name");
+	query->PushString("*");
+	query->PushOp(B_EQ);
+
+	entry_ref ref;
+	query->Fetch();
+
+	BFile* catFile;
+	Category* category;
+
+	while (query->GetNextRef(&ref) == B_OK) {
+		catFile = new BFile(&ref, B_READ_ONLY);
+		category = _FileToCategory(catFile);
+
+		if (category->GetName() == BString(B_TRANSLATE("Default")))
+			categories->AddItem(category, 0);
+		else if (!category->GetName().IsEmpty())
+			categories->AddItem(category);
+	}
+
+	delete(query);
+	return categories;
+}
+
+
+bool
+QueryDBManager::RemoveCategory(Category* category)
+{
+	entry_ref ref = _GetCategoryRef(category->GetName());
+	return RemoveCategory(ref);
+}
+
+
+bool
+QueryDBManager::RemoveCategory(entry_ref categoryRef)
+{
+	BEntry entry = BEntry(&categoryRef);
+	BString catName = BString();
+	BNode(&entry).ReadAttrString("Category:Name", &catName);
+
+	_ReplaceCategory(catName, BString(B_TRANSLATE("Default")));
+
+	if (_CategoryStatusSwitch(entry.Remove()) == B_OK)
+		return true;
+	return false;
+}
+
+
+entry_ref
+QueryDBManager::_GetEventRef(const char* name, time_t startDate)
+{
+	BQuery* query = new BQuery();
+	query->SetVolume(&fQueryVolume);
+
+	query->PushAttr("Event:Name");
+	query->PushString(name);
+	query->PushOp(B_EQ);
+
+	query->PushAttr("Event:Start");
+	query->PushUInt32(startDate);
+	query->PushOp(B_EQ);
+	query->PushOp(B_AND);
+
+	entry_ref ref;
+
+	if (query->Fetch() == B_OK)
+		query->GetNextRef(&ref);
+
+	delete(query);
+	return ref;
+}
+
+
+entry_ref
+QueryDBManager::_GetCategoryRef(const char* name)
+{
+	BQuery* query = new BQuery();
+	query->SetVolume(&fQueryVolume);
+
+	query->PushAttr("Category:Name");
+	query->PushString(name);
+	query->PushOp(B_EQ);
+
+	entry_ref ref;
+
+	if (query->Fetch() == B_OK)
+		query->GetNextRef(&ref);
+
+	delete(query);
+	return ref;
+}
+
+
+BList*
+QueryDBManager::_GetEventsOfInterval(time_t start, time_t end)
+{
+	BList* events = new BList();
+	BQuery* query = new BQuery();
+	query->SetVolume(&fQueryVolume);
+
+	query->PushAttr("Event:End");
+	query->PushUInt32(start);
+	query->PushOp(B_GE);
+	query->PushAttr("Event:Start");
+	query->PushUInt32(end);
+	query->PushOp(B_LE);
+	query->PushOp(B_AND);
+
+	query->PushAttr("Event:Status");
+	query->PushString("Cancelled");
+	query->PushOp(B_NE);
+	query->PushOp(B_AND);
+
+	query->Fetch();
+	entry_ref ref;
+
+	BFile* evFile;
+	Event* event;
+
+	while (query->GetNextRef(&ref) == B_OK) {
+		evFile = new BFile(&ref, B_READ_WRITE);
+		event = _FileToEvent(evFile);
+		events->AddItem(event);
+	}
+
+	delete(query);
+	return events;
+}
+
+
+status_t
+QueryDBManager::_GetItemOfId(const char* id, BFile* file)
+{
+	BQuery* query = new BQuery();
+	query->SetVolume(&fQueryVolume);
+
+	query->PushAttr("Calendar:ID");
+	query->PushString(id);
+	query->PushOp(B_EQ);
+
+	entry_ref ref;
+	status_t result = query->Fetch();
+
+	if (result == B_OK) {
+		entry_ref ref;
+		result = query->GetNextRef(&ref);
+
+		if (result == B_OK)
+			*file = BFile(&ref, B_READ_WRITE);
+	}
+
+	delete(query);
+	return result;
+}
+
+
+Category*
+QueryDBManager::_FileToCategory(BFile* file)
+{
+	BString name = BString();
+	BString color = BString();
+	BString idStr = BString();
+	file->ReadAttrString("Category:Name", &name);
+	file->ReadAttrString("Category:Color", &color);
+	file->ReadAttrString("Calendar:ID", &idStr);
+
+	return new Category(name, color, idStr.String());
+}
+
+
+Event*
+QueryDBManager::_FileToEvent(BFile* file)
+{
+	BString name  = BString();
+	BString catName = BString();
+	BString idStr = BString();
+	BString desc  = BString();
+	BString place = BString();
+	BString status = BString();
+	file->ReadAttrString("Event:Name", &name);
+	file->ReadAttrString("Event:Category", &catName);
+	file->ReadAttrString("Calendar:ID", &idStr);
+	file->ReadAttrString("Event:Description", &desc);
+	file->ReadAttrString("Event:Place", &place);
+	file->ReadAttrString("Event:Status", &status);
+
+	time_t start	= time(NULL);
+	time_t end		= time(NULL);
+	time_t updated	= time(NULL);
+	file->ReadAttr("Event:Start", B_TIME_TYPE, 0, &start, sizeof(time_t));
+	file->ReadAttr("Event:End", B_TIME_TYPE, 0, &end, sizeof(time_t));
+	file->ReadAttr("Event:Updated", B_TIME_TYPE, 0, &updated, sizeof(time_t));
+
+	bool allDay = false;
+	time_t dayStart	= BDateTime(BDate(start), BTime(0, 0, 0)).Time_t();
+	time_t dayEnd	= BDateTime(BDate(end), BTime(23, 59, 0)).Time_t();
+	if (dayStart <= start && start <= dayStart + 59
+		&& dayEnd <= end && end <= dayEnd + 59)
+		allDay = true;
+
+	bool isNotified = false;
+	if (status == BString("Notified"))
+		isNotified = true;
+
+	return new Event(name.String(), place.String(), desc.String(), allDay,
+					start, end, EnsureCategory(catName.String()), isNotified,
+					updated, true, idStr.String());
+}
+
+
+bool
+QueryDBManager::_CategoryToFile(Category* category, BFile* file)
+{
+	if (BString(category->GetName()).CountChars() < 3)
+		return false;
+
+	if (_CategoryStatusSwitch(file->InitCheck()) != B_OK)
+		return false;
+
+	BString type = BString("application/x-calendar-category");
+	file->WriteAttr("BEOS:TYPE", B_MIME_STRING_TYPE, 0, type.String(),
+					type.CountChars() + 1);
+
+	BString name = BString(category->GetName());
+	file->WriteAttr("Category:Name", B_STRING_TYPE, 0, name.String(),
+					name.CountChars() + 1);
+	
+	BString id = BString(category->GetId());
+	file->WriteAttr("Calendar:ID", B_STRING_TYPE, 0, id.String(),
+						id.CountChars() + 1);
+
+	BString color = category->GetHexColor();
+	file->WriteAttr("Category:Color", B_STRING_TYPE, 0, color.String(),
+						color.CountChars() + 1);
+	
+	return true;
+}
+
+
+bool
+QueryDBManager::_EventToFile(Event* event, BFile* file)
+{
+	if (BString(event->GetName()).CountChars() < 3)
+		return false;
+
+	if (_EventStatusSwitch(file->InitCheck()) != B_OK)
+		return false;
+
+	BString status = BString("Unnotified");
+	if (!event->GetStatus()) {
+		status = BString("Cancelled");
+		entry_ref ref = _GetEventRef(event->GetName(), event->GetStartDateTime());
+		BEntry entry = BEntry(&ref);
+		entry.MoveTo(fCancelledDir);
+	} else if (event->IsNotified())
+		status = BString("Notified");
+
+	file->WriteAttr("Event:Status", B_STRING_TYPE, 0, status.String(),
+						status.CountChars() + 1);
+
+	BString type = BString("application/x-calendar-event");
+	file->WriteAttr("BEOS:TYPE", B_MIME_STRING_TYPE, 0, type.String(),
+					type.CountChars() + 1);
+	
+	BString name = BString(event->GetName());
+	file->WriteAttr("Event:Name", B_STRING_TYPE, 0, name.String(),
+					name.CountChars() + 1);
+
+	BString id = BString(event->GetId());
+	file->WriteAttr("Calendar:ID", B_STRING_TYPE, 0, id.String(),
+					id.CountChars() + 1);
+
+	BString catName = BString(event->GetCategory()->GetName());
+	file->WriteAttr("Event:Category", B_STRING_TYPE, 0, catName.String(),
+					catName.CountChars() + 1);
+
+	BString place = event->GetPlace();
+	file->WriteAttr("Event:Place", B_STRING_TYPE, 0, place.String(),
+					place.CountChars() + 1);
+
+	BString desc = event->GetDescription();
+	file->WriteAttr("Event:Description", B_STRING_TYPE, 0, desc.String(),
+					desc.CountChars() + 1);
+
+	time_t updated = event->GetUpdated();
+	file->WriteAttr("Event:Updated", B_TIME_TYPE, 0, &updated,
+					sizeof(time_t));
+
+	time_t start = event->GetStartDateTime();
+	file->WriteAttr("Event:Start", B_TIME_TYPE, 0, &start, sizeof(time_t));
+
+	time_t end = event->GetEndDateTime();
+	file->WriteAttr("Event:End", B_TIME_TYPE, 0, &end, sizeof(time_t));
+
+	return true;
+}
+
+
+// Replace the category of all events of oldCategory with newCategory.
+void
+QueryDBManager::_ReplaceCategory(BString oldCategory, BString newCategory)
+{
+	BQuery* query = new BQuery();
+	query->SetVolume(&fQueryVolume);
+
+	query->PushAttr("Event:Category");
+	query->PushString(oldCategory.String());
+	query->PushOp(B_EQ);
+
+	query->Fetch();
+	entry_ref ref;
+
+	BFile* evFile;
+	Event* event;
+
+	while (query->GetNextRef(&ref) == B_OK) {
+		evFile = new BFile(&ref, B_WRITE_ONLY);
+		evFile->WriteAttr("Event:Category", B_STRING_TYPE, 0,
+						newCategory.String(), newCategory.CountChars() + 1);
+	}
+}
+
+
+status_t
+QueryDBManager::_CategoryStatusSwitch(status_t result)
+{
+	switch (result)
+	{
+		case B_BAD_VALUE:
+		{
+			BAlert* alert = new BAlert(B_TRANSLATE("Category file"),
+				B_TRANSLATE("Couldn't open category file because the path is not specified. "
+				"It usually means that the programmer made a mistake. "
+				"There is nothing you can do about it. Sorry."),
+				B_TRANSLATE("OK"), NULL, NULL,
+				B_WIDTH_AS_USUAL, B_WARNING_ALERT);
+			alert->Go();
+			break;
+		}
+		case B_PERMISSION_DENIED:
+		{
+			BAlert* alert = new BAlert(B_TRANSLATE("Category file"),
+				B_TRANSLATE("Couldn't open category file because permission was denied. "
+				"It usually means that you don't have read permissions to the event "
+				"file or its parent directory, usually within the settings directory."
+				"Find out the file's location and try changing its permissions."),
+				B_TRANSLATE("OK"), NULL, NULL,
+				B_WIDTH_AS_USUAL, B_WARNING_ALERT);
+			alert->Go();
+			break;
+		}
+		case B_NO_MEMORY:
+		{
+			BAlert* alert = new BAlert(B_TRANSLATE("Category file"),
+				B_TRANSLATE("There is not enough memory available on your system to save the "
+				"category file. If you want to have event updates saved, try closing a few"
+				"applications and try again."),
+				B_TRANSLATE("OK"), NULL, NULL,
+				B_WIDTH_AS_USUAL, B_WARNING_ALERT);
+			alert->Go();
+			break;
+		}
+	}
+
+	return result;
+}
+
+
+status_t
+QueryDBManager::_EventStatusSwitch(status_t result)
+{
+	switch (result)
+	{
+		case B_BAD_VALUE:
+		{
+			BAlert* alert = new BAlert(B_TRANSLATE("Event file"),
+				B_TRANSLATE("Couldn't open event file because the path is not specified. "
+				"It usually means that the programmer made a mistake. "
+				"There is nothing you can do about it. Sorry."),
+				B_TRANSLATE("OK"), NULL, NULL,
+				B_WIDTH_AS_USUAL, B_WARNING_ALERT);
+			alert->Go();
+			break;
+		}
+		case B_PERMISSION_DENIED:
+		{
+			BAlert* alert = new BAlert(B_TRANSLATE("Event file"),
+				B_TRANSLATE("Couldn't open event file because permission was denied. "
+				"It usually means that you don't have read permissions to the event "
+				"file or its parent directory, usually within the settings directory."
+				"Find out the file's location and try changing its permissions."),
+				B_TRANSLATE("OK"), NULL, NULL,
+				B_WIDTH_AS_USUAL, B_WARNING_ALERT);
+			alert->Go();
+			break;
+		}
+		case B_NO_MEMORY:
+		{
+			BAlert* alert = new BAlert(B_TRANSLATE("Event file"),
+				B_TRANSLATE("There is not enough memory available on your system to save the "
+				"event file. If you want to have event updates saved, try closing a few"
+				"applications and try again."),
+				B_TRANSLATE("OK"), NULL, NULL,
+				B_WIDTH_AS_USUAL, B_WARNING_ALERT);
+			alert->Go();
+			break;
+		}
+	}
+
+	return result;
+}
+
+
+bool
+QueryDBManager::_CategoryMimetype()
+{
+	BMessage info;
+	BMimeType mime("application/x-calendar-category" );
+	if (mime.IsInstalled())
+		return true;
+
+	mime.GetAttrInfo(&info);
+
+	mime.SetShortDescription("Calendar Category");
+	mime.SetLongDescription("Category of calendar events");
+
+	_AddAttribute(info, "Category:Name",	"Name", B_STRING_TYPE, true, 300);
+	_AddAttribute(info, "Category:Color",	"Color", B_STRING_TYPE, true, 100);
+	_AddAttribute(info, "Calendar:ID",		"ID", B_STRING_TYPE, true, 100);
+
+	return mime.SetAttrInfo( &info );
+}
+
+
+bool
+QueryDBManager::_EventMimetype()
+{
+	BMessage info;
+	BMimeType mime("application/x-calendar-event" );
+	if (mime.IsInstalled())
+		return true;
+
+	mime.GetAttrInfo(&info);
+
+	mime.SetShortDescription("Calendar Event");
+	mime.SetLongDescription("Generic calendar event");
+
+	_AddAttribute(info, "Event:Name",	"Name",		B_STRING_TYPE, true, 300);
+	_AddAttribute(info, "Event:Start",	"Start",	B_TIME_TYPE, true, 150);
+	_AddAttribute(info, "Event:End",	"End",		B_TIME_TYPE, true, 150);
+	_AddAttribute(info, "Event:Category", "Category",
+													B_STRING_TYPE, false, 200);
+	_AddAttribute(info, "Event:Description", "Description",
+													B_STRING_TYPE, true, 200);
+	_AddAttribute(info, "Event:Place",	"Place",	B_STRING_TYPE, true, 200);
+	_AddAttribute(info, "Event:Updated", "Updated",	B_TIME_TYPE, true, 150);
+	_AddAttribute(info, "Event:Status",	"Status",	B_STRING_TYPE, true, 50);
+	_AddAttribute(info, "Calendar:ID",	"ID",		B_STRING_TYPE, true, 100);
+
+	return mime.SetAttrInfo( &info );
+}
+
+
+void
+QueryDBManager::_AddIndices()
+{
+	int32 cookie = 0;
+	dev_t device;
+
+	while ((device = next_dev(&cookie)) >= B_OK) {
+		fs_info info;
+		if (fs_stat_dev(device, &info) < 0
+			|| (info.flags & B_FS_HAS_QUERY) == 0)
+			continue;
+
+		fs_create_index(device, "Event:Name",		B_STRING_TYPE, 0);
+		fs_create_index(device, "Event:Category",	B_STRING_TYPE, 0);
+		fs_create_index(device, "Event:Place",		B_STRING_TYPE, 0);
+		fs_create_index(device, "Event:Description",B_STRING_TYPE, 0);
+		fs_create_index(device, "Event:Start",		B_INT32_TYPE, 0);
+		fs_create_index(device, "Event:End",		B_INT32_TYPE, 0);
+		fs_create_index(device, "Event:Updated",	B_INT32_TYPE, 0);
+		fs_create_index(device, "Event:Status",		B_STRING_TYPE, 0);
+		fs_create_index(device, "Calendar:ID",		B_STRING_TYPE, 0);
+		fs_create_index(device, "Category:Name",	B_STRING_TYPE, 0);
+		fs_create_index(device, "Category:Color",	B_STRING_TYPE, 0);
+	}
+}
+
+
+void
+QueryDBManager::_AddAttribute(BMessage& msg, const char* name,
+							const char* publicName, int32 type, bool viewable,
+							int32 width)
+{
+	msg.AddString( "attr:name", name );
+	msg.AddString( "attr:public_name", publicName );
+	msg.AddInt32( "attr:type", type );
+	msg.AddInt32( "attr:width", width );
+	msg.AddInt32( "attr:alignment", B_ALIGN_LEFT );
+	msg.AddBool( "attr:extra", false );
+	msg.AddBool( "attr:viewable", viewable );
+	msg.AddBool( "attr:editable", true );
+}
+
+
+// Create a file with name similar to the given one. If a file of the given
+// name already exists, then add a unique number to the end of it.
+status_t
+QueryDBManager::_CreateUniqueFile(BDirectory* dir, BString name,
+								BFile* newFile)
+{
+	if (dir->Contains(name.String())) {
+		int suffix = 1;
+		char suffixStr[3];
+		BStringList sections = BStringList();
+		bool result = name.Split(" - ", true, sections);
+
+		if (result && sections.CountStrings() > 1) {
+			sscanf(sections.Last().String(), "%u", &suffix);
+			if (suffix > 0)
+				suffix++;
+
+			sections.Remove(sections.CountStrings() - 1);
+			name = sections.Join(" - ");
+		}
+
+		sprintf(suffixStr, "%u", suffix);
+		name += " - ";
+		name += suffixStr;
+
+		return _CreateUniqueFile(dir, name, newFile);
+	}	
+
+	dir->CreateFile(name.String(), newFile, true);
+	return B_OK;
+}
+
+

--- a/src/db/QueryDBManager.cpp
+++ b/src/db/QueryDBManager.cpp
@@ -21,6 +21,7 @@
 #include <StringList.h>
 #include <VolumeRoster.h>
 
+#include "App.h"
 #include "Category.h"
 #include "Event.h"
 #include "Preferences.h"
@@ -86,12 +87,6 @@ QueryDBManager::_Initialise()
 	if (fCategoryDir->InitCheck() == B_ENTRY_NOT_FOUND) {
 		fCategoryDir->CreateDirectory(categoryPath.Path(), fCategoryDir);
 	}
-
-	// Settings
-	settingsPath = BPath(rootPath);
-	settingsPath.Append("settings");
-	fPreferences = new Preferences();
-	fPreferences->Load(settingsPath.Path());
 
 	BVolumeRoster volRoster;
 	volRoster.GetBootVolume(&fQueryVolume);
@@ -401,12 +396,13 @@ QueryDBManager::GetAllCategories()
 
 	BFile* catFile;
 	Category* category;
+	BString defaultCat = ((App*)be_app)->GetPreferences()->fDefaultCategory;
 
 	while (query->GetNextRef(&ref) == B_OK) {
 		catFile = new BFile(&ref, B_READ_ONLY);
 		category = _FileToCategory(catFile);
 
-		if (category->GetName() == fPreferences->fDefaultCategory)
+		if (category->GetName() == defaultCat)
 			categories->AddItem(category, 0);
 		else if (!category->GetName().IsEmpty())
 			categories->AddItem(category);

--- a/src/db/QueryDBManager.cpp
+++ b/src/db/QueryDBManager.cpp
@@ -38,7 +38,7 @@ const char* kCategoryDir	= "categories";
 
 QueryDBManager::QueryDBManager()
 {
-	_Initialise();
+	_Initialize();
 }
 
 
@@ -49,7 +49,7 @@ QueryDBManager::~QueryDBManager()
 
 
 void
-QueryDBManager::_Initialise()
+QueryDBManager::_Initialize()
 {
 	BPath rootPath;
 	BPath eventPath;

--- a/src/db/QueryDBManager.h
+++ b/src/db/QueryDBManager.h
@@ -36,6 +36,7 @@ public:
 		Event*		GetEvent(const char* name, time_t startTime);
 		BList*		GetEventsOfDay(BDate& date);
 		BList*		GetEventsOfWeek(BDate& date);
+		BList*		GetEventsOfCategory(Category* category);
 		BList*		GetEventsToNotify(BDateTime dateTime);
 		bool		RemoveEvent(Event* event);
 		bool		RemoveEvent(entry_ref eventRef);

--- a/src/db/QueryDBManager.h
+++ b/src/db/QueryDBManager.h
@@ -21,6 +21,7 @@ extern const char* kCancelledDir;
 extern const char* kCategoryDir;
 extern const char* kDatabaseName;
 
+
 class QueryDBManager {
 public:
 					QueryDBManager();
@@ -56,7 +57,7 @@ private:
 	entry_ref		_GetCategoryRef(const char* name);
 
 	BList*			_GetEventsOfInterval(time_t start, time_t end);
-	status_t		_GetItemOfId(const char* id, BFile* file);
+	status_t		_GetFileOfId(const char* id, BFile* file);
 
 	Category*		_FileToCategory(BFile* file);
 	Event*			_FileToEvent(BFile* file);

--- a/src/db/QueryDBManager.h
+++ b/src/db/QueryDBManager.h
@@ -87,7 +87,5 @@ private:
 	BDirectory*		fCancelledDir;
 	BDirectory*		fCategoryDir;
 	BVolume			fQueryVolume;
-
-	Preferences*	fPreferences;
 };
 #endif // _QDB_MANAGER_H_

--- a/src/db/QueryDBManager.h
+++ b/src/db/QueryDBManager.h
@@ -19,6 +19,7 @@ extern const char* kDirectoryName;
 extern const char* kEventDir;
 extern const char* kCancelledDir;
 extern const char* kCategoryDir;
+extern const char* kDatabaseName;
 
 class QueryDBManager {
 public:
@@ -66,6 +67,8 @@ private:
 	
 	status_t		_CategoryStatusSwitch(status_t);
 	status_t		_EventStatusSwitch(status_t);
+
+	void			_ImportFromSQL(BPath dbPath);
 
 	bool			_CategoryMimetype();
 	bool			_EventMimetype();

--- a/src/db/QueryDBManager.h
+++ b/src/db/QueryDBManager.h
@@ -53,7 +53,7 @@ public:
 
 private:
 
-	void			_Initialise();
+	void			_Initialize();
 
 	entry_ref		_GetEventRef(const char* name, time_t startDate);
 	entry_ref		_GetCategoryRef(const char* name);

--- a/src/db/QueryDBManager.h
+++ b/src/db/QueryDBManager.h
@@ -10,6 +10,7 @@
 #include <Path.h>
 #include <Volume.h>
 
+#include "Preferences.h"
 
 class Category;
 class Event;
@@ -85,5 +86,7 @@ private:
 	BDirectory*		fCancelledDir;
 	BDirectory*		fCategoryDir;
 	BVolume			fQueryVolume;
+
+	Preferences*	fPreferences;
 };
 #endif // _QDB_MANAGER_H_

--- a/src/db/QueryDBManager.h
+++ b/src/db/QueryDBManager.h
@@ -34,6 +34,7 @@ public:
 
 		Event*		GetEvent(const char* id);
 		Event*		GetEvent(const char* name, time_t startTime);
+		Event*		GetEvent(entry_ref ref);
 		BList*		GetEventsOfDay(BDate& date);
 		BList*		GetEventsOfWeek(BDate& date);
 		BList*		GetEventsOfCategory(Category* category);
@@ -46,6 +47,7 @@ public:
 		bool		UpdateCategory(Category* category,
 						Category* newCategory);
 		Category*	GetCategory(const char* name);
+		Category*	GetCategory(entry_ref ref);
 		Category*	EnsureCategory(const char* name);
 		BList*		GetAllCategories();
 		bool		RemoveCategory(Category* category);

--- a/src/db/QueryDBManager.h
+++ b/src/db/QueryDBManager.h
@@ -1,0 +1,85 @@
+/*
+ * All rights reserved. Distributed under the terms of the MIT License.
+ */
+#ifndef _QDB_MANAGER_H_
+#define _QDB_MANAGER_H_
+
+
+#include <DateTime.h>
+#include <Directory.h>
+#include <Path.h>
+#include <Volume.h>
+
+
+class Category;
+class Event;
+
+
+extern const char* kDirectoryName;
+extern const char* kEventDir;
+extern const char* kCancelledDir;
+extern const char* kCategoryDir;
+
+class QueryDBManager {
+public:
+					QueryDBManager();
+					~QueryDBManager();
+
+		bool		AddEvent(Event* event);
+		bool		UpdateEvent(Event* event, Event* newEvent);
+		bool		UpdateNotifiedEvent(const char* id);
+
+		Event*		GetEvent(const char* id);
+		Event*		GetEvent(const char* name, time_t startTime);
+		BList*		GetEventsOfDay(BDate& date);
+		BList*		GetEventsOfWeek(BDate& date);
+		BList*		GetEventsToNotify(BDateTime dateTime);
+		bool		RemoveEvent(Event* event);
+		bool		RemoveEvent(entry_ref eventRef);
+		bool		RemoveCancelledEvents();
+
+		bool		AddCategory(Category* category);
+		bool		UpdateCategory(Category* category,
+						Category* newCategory);
+		Category*	GetCategory(const char* name);
+		Category*	EnsureCategory(const char* name);
+		BList*		GetAllCategories();
+		bool		RemoveCategory(Category* category);
+		bool		RemoveCategory(entry_ref categoryRef);
+
+private:
+
+	void			_Initialise();
+
+	entry_ref		_GetEventRef(const char* name, time_t startDate);
+	entry_ref		_GetCategoryRef(const char* name);
+
+	BList*			_GetEventsOfInterval(time_t start, time_t end);
+	status_t		_GetItemOfId(const char* id, BFile* file);
+
+	Category*		_FileToCategory(BFile* file);
+	Event*			_FileToEvent(BFile* file);
+	bool			_CategoryToFile(Category* category, BFile* file);
+	bool			_EventToFile(Event* event, BFile* file);
+
+	void			_ReplaceCategory(BString oldCategory, BString newCategory);
+	
+	status_t		_CategoryStatusSwitch(status_t);
+	status_t		_EventStatusSwitch(status_t);
+
+	bool			_CategoryMimetype();
+	bool			_EventMimetype();
+	void			_AddIndices();
+
+	void			_AddAttribute(BMessage& msg, const char* name,
+								const char* publicName, int32 type,
+								bool viewable, int32 width);
+	status_t		_CreateUniqueFile(BDirectory*, BString, BFile*);
+
+
+	BDirectory*		fEventDir;
+	BDirectory*		fCancelledDir;
+	BDirectory*		fCategoryDir;
+	BVolume			fQueryVolume;
+};
+#endif // _QDB_MANAGER_H_

--- a/src/db/SQLiteManager.cpp
+++ b/src/db/SQLiteManager.cpp
@@ -489,6 +489,49 @@ SQLiteManager::GetEventsToNotify(BDateTime dateTime)
 }
 
 
+BList*
+SQLiteManager::GetAllEvents()
+{
+	BList* events = new BList();
+	sqlite3_stmt* stmt;
+
+	BString sql("SELECT * FROM EVENTS;");
+
+	int rc = sqlite3_prepare_v2(db, sql.String(), -1, &stmt, NULL);
+
+	if (rc != SQLITE_OK) {
+		fprintf(stderr, "Failed to fetch data: %s\n", sqlite3_errmsg(db));
+		return events;
+	}
+
+	while (rc = sqlite3_step(stmt) == SQLITE_ROW) {
+		const char* uuid = (const char*)sqlite3_column_text(stmt, 0);
+		const char* name = (const char*)sqlite3_column_text(stmt, 1);
+		const char* place = (const char*)sqlite3_column_text(stmt, 2);
+		const char* description = (const char*)sqlite3_column_text(stmt, 3);
+		bool allday = ((int)sqlite3_column_int(stmt, 4))? true : false;
+		time_t start = (time_t)sqlite3_column_int(stmt, 5);
+		time_t end = (time_t)sqlite3_column_int(stmt, 6);
+
+		Category* category = GetCategory((const char*)sqlite3_column_text(stmt, 7));
+		if (category == NULL) {
+			fprintf(stderr, "Error: Received NULL category\n");
+		} else {
+			bool notified = ((int)sqlite3_column_int(stmt, 8))? true : false;
+			time_t updated = (time_t)sqlite3_column_int(stmt, 9);
+			bool status = ((int)sqlite3_column_int(stmt, 10))? true : false;
+			Event* event = new Event(name, place, description, allday,
+			start, end, category, notified, updated, status, uuid);
+
+			events->AddItem(event);
+		}
+	}
+
+	sqlite3_finalize(stmt);
+	return events;
+}
+
+
 bool
 SQLiteManager::AddCategory(Category* category)
 {

--- a/src/db/SQLiteManager.h
+++ b/src/db/SQLiteManager.h
@@ -32,6 +32,7 @@ public:
 		BList*		GetEventsOfDay(BDate& date);
 		BList*		GetEventsOfWeek(BDate& date);
 		BList*		GetEventsToNotify(BDateTime dateTime);
+		BList*		GetAllEvents();
 		bool		RemoveEvent(Event* event);
 		bool		RemoveCancelledEvents();
 

--- a/src/plugin/GoogleCalendar/EventSync.cpp
+++ b/src/plugin/GoogleCalendar/EventSync.cpp
@@ -22,7 +22,7 @@
 #include "Event.h"
 #include "EventSync.h"
 #include "Requests.h"
-#include "SQLiteManager.h"
+#include "QueryDBManager.h"
 
 
 // Don't update status property to Google Calendar for active events(status=true)
@@ -123,7 +123,7 @@ EventSync::EventSync()
 	:
 	fAuthCode()
 {
-	fDBManager = new SQLiteManager();
+	fDBManager = new QueryDBManager();
 	fEvents = new BList();
 	fCancelledEvents = new BStringList();
 }

--- a/src/plugin/GoogleCalendar/EventSync.h
+++ b/src/plugin/GoogleCalendar/EventSync.h
@@ -10,7 +10,7 @@
 
 class BList;
 class Event;
-class SQLiteManager;
+class QueryDBManager;
 
 
 #define CLIENT_SECRET "sH095g9EzY5BxwI-DHIlqVXr"
@@ -68,7 +68,7 @@ class EventSync {
 		BString 					fToken;
 		BString 					fRefreshToken;
 		BString						fAuthCode;
-		SQLiteManager*				fDBManager;
+		QueryDBManager*				fDBManager;
 		BString						fLastSyncToken;
 		BList*						fEvents;
 		BStringList*				fCancelledEvents;


### PR DESCRIPTION
Uses a query DB manager as a drop-in replacement for the SQL manager. All SQL events are imported automatically, and behavior should be same-- with the exception of the 'default' category and 'All Day' events.

An option is added to preferences to change the default category, and any event starting at 00:00 and ending at 23:59 is counted as 'All Day' by the db manager (as opposed to using a dedicated trait).

This is my first go at anything really query-backed, so there's probably a good bit wrong here. But it seems like it's been working well on my systems for a few days.