### PR TITLE
Add missing return statements and fix format specifier

### DIFF
--- a/src/plugin/GoogleCalendar/EventSync.cpp
+++ b/src/plugin/GoogleCalendar/EventSync.cpp
@@ -470,6 +470,8 @@ EventSync::AddEvent(Event* event)
 	if (Requests::Request(url, B_HTTP_POST, headers, NULL, &jsonString, reply)
 		== B_ERROR)
 		return B_ERROR;
+
+	return B_OK;
 }
 
 
@@ -484,6 +486,8 @@ EventSync::DeleteEvent(Event* event)
 	if (Requests::Request(endpoint, B_HTTP_DELETE, NULL, NULL, NULL, reply)
 		== B_ERROR)
 		return B_ERROR;
+
+	return B_OK;
 }
 
 
@@ -541,7 +545,7 @@ EventSync::RFC3339ToTime(const char* timeString, EventDateType type)
 	}
 
 	else if (static_cast<EventDateType>(type) == kEventUpdateDate) {
-		sscanf (timeString, "%d-%d-%dT%d:%d:%d.%d'Z'", &year, &month, &day,
+		sscanf (timeString, "%d-%d-%dT%d:%d:%d.%*d'Z'", &year, &month, &day,
            &hour, &minute, &second);
 	}
 

--- a/src/plugin/GoogleCalendar/SynchronizationLoop.cpp
+++ b/src/plugin/GoogleCalendar/SynchronizationLoop.cpp
@@ -31,4 +31,6 @@ SynchronizationLoop(void* data)
 		statusMessage.AddBool("status", true);
 
 	msgr.SendMessage(&statusMessage);
+
+	return B_OK;
 }


### PR DESCRIPTION
Fixes #36: Syncing with Google Calendar causes the application to crash.  It appears as though the crash was a result of a problematic format specifier as well as undefined behavior caused by missing return statements.