### PR TITLE
Prevent selected date from inadvertently being modified

### DIFF
--- a/src/db/QueryDBManager.cpp
+++ b/src/db/QueryDBManager.cpp
@@ -246,7 +246,7 @@ QueryDBManager::GetEventsOfDay(BDate& date)
 
 
 BList*
-QueryDBManager::GetEventsOfWeek(BDate& date)
+QueryDBManager::GetEventsOfWeek(BDate date)
 {
 	date.AddDays(-date.DayOfWeek()+1);
 	time_t weekStart = BDateTime(date, BTime(0, 0, 0)).Time_t();

--- a/src/db/QueryDBManager.h
+++ b/src/db/QueryDBManager.h
@@ -36,7 +36,7 @@ public:
 		Event*		GetEvent(const char* name, time_t startTime);
 		Event*		GetEvent(entry_ref ref);
 		BList*		GetEventsOfDay(BDate& date);
-		BList*		GetEventsOfWeek(BDate& date);
+		BList*		GetEventsOfWeek(BDate date);
 		BList*		GetEventsOfCategory(Category* category);
 		BList*		GetEventsToNotify(BDateTime dateTime);
 		bool		RemoveEvent(Event* event);


### PR DESCRIPTION
The method QueryDBManager::GetEventsOfWeek inadvertently modifies the date which leads to the event view displaying incorrect events.