### PR TITLE
Move deleted events to Trash, cancel as necessary

### DIFF
--- a/src/DayView.cpp
+++ b/src/DayView.cpp
@@ -106,24 +106,25 @@ DayView::MessageReceived(BMessage* message)
 			if (selection >= 0) {
 				Event* event = ((Event*)fEventList->ItemAt(selection));
 
-				BAlert* alert = new BAlert(B_TRANSLATE("Confirm delete"),
-					B_TRANSLATE("Are you sure you want to delete the selected event?"),
-					NULL, B_TRANSLATE("OK"), B_TRANSLATE("Cancel"), B_WIDTH_AS_USUAL, B_WARNING_ALERT);
+				BString title("Confirm delete");
+				BString subtitle("Are you sure you want to move the selected event to Trash?");
+				if (fDBManager->SyncEnabled()) {
+					title = "Confirm cancelation";
+					subtitle = "Are you sure you want to cancel the selected event?";
+				}
+
+				BAlert* alert = new BAlert(B_TRANSLATE(title.String()),
+					B_TRANSLATE(subtitle.String()), NULL, B_TRANSLATE("OK"),
+					B_TRANSLATE("Cancel"), B_WIDTH_AS_USUAL, B_WARNING_ALERT);
 
 				alert->SetShortcut(1, B_ESCAPE);
 				int32 button_index = alert->Go();
 
 				if (button_index == 0) {
-					Event newEvent(*event);
-					newEvent.SetStatus(false);
-					newEvent.SetUpdated(time(NULL));
-					fDBManager->UpdateEvent(event, &newEvent);
-					Window()->LockLooper();
+					fDBManager->CancelEvent(event);
 					LoadEvents();
-					Window()->UnlockLooper();
 				}
 			}
-
 			break;
 		}
 		case kDayView:

--- a/src/EventWindow.cpp
+++ b/src/EventWindow.cpp
@@ -347,18 +347,22 @@ EventWindow::OnSaveClick()
 void
 EventWindow::OnDeleteClick()
 {
-	BAlert* alert = new BAlert(B_TRANSLATE("Confirm delete"),
-		B_TRANSLATE("Are you sure you want to delete this event?"),
-		NULL, B_TRANSLATE("OK"), B_TRANSLATE("Cancel"), B_WIDTH_AS_USUAL, B_WARNING_ALERT);
+	BString title("Confirm delete");
+	BString subtitle("Are you sure you want to move this event to Trash?");
+	if (fDBManager->SyncEnabled()) {
+		title = "Confirm cancelation";
+		subtitle = "Are you sure you want to cancel this event?";
+	}
+
+	BAlert* alert = new BAlert(B_TRANSLATE(title.String()),
+		B_TRANSLATE(subtitle.String()), NULL, B_TRANSLATE("OK"),
+		B_TRANSLATE("Cancel"), B_WIDTH_AS_USUAL, B_WARNING_ALERT);
 
 	alert->SetShortcut(1, B_ESCAPE);
 	int32 button_index = alert->Go();
 
 	if (button_index == 0) {
-		Event newEvent(*fEvent);
-		newEvent.SetStatus(false);
-		newEvent.SetUpdated(time(NULL));
-		fDBManager->UpdateEvent(fEvent, &newEvent);
+		fDBManager->CancelEvent(fEvent);
 		CloseWindow();
 	}
 }

--- a/src/db/QueryDBManager.h
+++ b/src/db/QueryDBManager.h
@@ -39,6 +39,7 @@ public:
 		BList*		GetEventsOfWeek(BDate date);
 		BList*		GetEventsOfCategory(Category* category);
 		BList*		GetEventsToNotify(BDateTime dateTime);
+		bool		CancelEvent(Event* event);
 		bool		RemoveEvent(Event* event);
 		bool		RemoveEvent(entry_ref eventRef);
 		bool		RemoveCancelledEvents();
@@ -52,6 +53,8 @@ public:
 		BList*		GetAllCategories();
 		bool		RemoveCategory(Category* category);
 		bool		RemoveCategory(entry_ref categoryRef);
+
+		bool		SyncEnabled();
 
 private:
 
@@ -88,6 +91,8 @@ private:
 	BDirectory*		fEventDir;
 	BDirectory*		fCancelledDir;
 	BDirectory*		fCategoryDir;
+	BDirectory*		fTrashDir;
 	BVolume			fQueryVolume;
+	bool			fSyncEnabled;
 };
 #endif // _QDB_MANAGER_H_


### PR DESCRIPTION
Cancelled events are only used for Google Sync, so canceling every event is unnecessary. It does give the user a nice second chance to undo any deletions, though.

This makes it so events are only cancelled if sync is used, and moves deleted events to the user's Trash (rather than just purging them).