### PR TITLE
Swap forward slash with division slash in filename

### DIFF
--- a/src/db/QueryDBManager.cpp
+++ b/src/db/QueryDBManager.cpp
@@ -1052,7 +1052,8 @@ QueryDBManager::_MigrateCancellations(BPath cancelPath)
 status_t
 QueryDBManager::_CreateUniqueFile(BDirectory* dir, BString name, BFile* newFile)
 {
-	return dir->CreateFile(_UniqueFilename(dir, name).String(), newFile, true);
+	return dir->CreateFile(_UniqueFilename(dir,
+		name.ReplaceAllChars("/","∕", 0)).String(), newFile, true);
 }
 
 


### PR DESCRIPTION
Better fix for #82?
BeFS supports all UTF-8 characters except forward slash.  So just swap it out for something that looks a lot like it... the division slash.
Did a quick test and it seems to work.  Try making a new event with a slashed date in it such as Birthday 11/22/21 and then deleted the event.  It shows up in trash with the division slash in place of the forward slash.  Restoring it and then checking in Calendar for the event, it shows back up with the forward slashes in the event name.

@JadedCtrl please check and make sure it works for you.

