### PR TITLE
Tint calendar highlight color per "busyness"

### DIFF
--- a/src/CalendarView.cpp
+++ b/src/CalendarView.cpp
@@ -1,6 +1,9 @@
 /*
- * Copyright 2017 Jadedctrl
+ * Copyright 2007-2011, Haiku, Inc. All Rights Reserved.
+ * Copyright 2020-2021 Jaidyn Levesque, jadedctrl@teknik.io
  * All rights reserved. Distributed under the terms of the MIT license.
+ * Authors:
+ *		Julun <host.haiku@gmx.de>
  */
 
 #include "CalendarView.h"
@@ -50,7 +53,7 @@ CalendarView::_Init ()
 
 void
 CalendarView::DrawDay (BView* owner, BRect frame, const char* text,
-	bool isSelected, bool isEnabled, bool focus, bool highlight)
+	bool isSelected, bool isEnabled, bool focus, bool isHighlight)
 {
 	int drawnYear  = Date().Year();
 	int drawnMonth = Date().Month();
@@ -61,11 +64,120 @@ CalendarView::DrawDay (BView* owner, BRect frame, const char* text,
 	if (isEnabled == 0 && drawnDay < 15)  { drawnMonth++; }
 	if (drawnMonth < 1)  { drawnMonth += 12; drawnYear--; }
 	if (drawnMonth > 12) { drawnMonth -= 12; drawnYear++; }
-
 	BDate drawnDate = BDate(Date().Year(), drawnMonth, drawnDay);
-	int currentEventsCount = fDBManager->GetEventsOfDay(drawnDate)->CountItems();
 
-	if (currentEventsCount > 0) { highlight = true; }
+	int eventCount = fDBManager->GetEventsOfDay(drawnDate)->CountItems();
+	if (isEnabled == false && eventCount != 0)
+		eventCount = 1;
 
-	BCalendarView::DrawDay(owner, frame, text, isSelected, isEnabled, focus, highlight);
+	rgb_color bgColor = ui_color(B_LIST_BACKGROUND_COLOR);
+	rgb_color textColor = ui_color(B_LIST_ITEM_TEXT_COLOR);
+
+	if (isSelected == true) {
+		bgColor = ui_color(B_LINK_ACTIVE_COLOR);
+		textColor = ui_color(B_LIST_SELECTED_ITEM_TEXT_COLOR);
+	} else if (eventCount > 0) {
+		bgColor = TintColor(bgColor, bgColor, eventCount);
+		textColor = ui_color(B_LIST_SELECTED_ITEM_TEXT_COLOR);
+	}
+
+	if (focus == true && isSelected == false)
+		textColor = keyboard_navigation_color();
+
+	if (isEnabled == false)
+		textColor = TintColor(textColor, textColor, 2);
+
+	// Tint in case of poor background/text contrast
+	float brightDiff = bgColor.Brightness() - textColor.Brightness();
+	if (brightDiff < 30 && brightDiff > -30)
+		textColor = TintColor(textColor, textColor, 2);
+
+	isHighlight = (eventCount > 0 && isEnabled == true);
+	_DrawItem(owner, frame, text, isHighlight, focus, bgColor, textColor);
+}
+
+
+void
+CalendarView::_DrawItem(BView* owner, BRect frame, const char* text,
+	bool isHighlight, bool focus, rgb_color bgColor, rgb_color textColor)
+{
+	rgb_color lColor = LowColor();
+	rgb_color highColor = HighColor();
+
+	SetHighColor(bgColor);
+	SetLowColor(bgColor);
+
+	FillRect(frame.InsetByCopy(1.0, 1.0));
+
+	if (focus) {
+		rgb_color focusColor = keyboard_navigation_color();
+		SetHighColor(focusColor);
+		StrokeRect(frame.InsetByCopy(1.0, 1.0));
+	}
+
+	SetHighColor(textColor);
+
+	float offsetH = frame.Width() / 2.0;
+	float offsetV = frame.Height() / 2.0 + FontHeight(owner) / 2.0 - 2.0;
+
+	BFont font(be_plain_font);
+	if (isHighlight)
+		font.SetFace(B_BOLD_FACE);
+	else
+		font.SetFace(B_REGULAR_FACE);
+	SetFont(&font);
+
+	DrawString(text, BPoint(frame.right - offsetH - StringWidth(text) / 2.0,
+			frame.top + offsetV));
+
+	SetLowColor(lColor);
+	SetHighColor(highColor);
+}
+
+
+rgb_color
+TintColor(rgb_color color, rgb_color base, int severity)
+{
+	bool dark = false;
+	if (base.Brightness() < 127)
+		dark = true;
+
+	switch (severity) {
+		case 0:
+			return color;
+		case 1:
+			if (dark == true)
+				return tint_color(color, B_LIGHTEN_1_TINT + 0.1f);
+			else
+				return tint_color(color, B_DARKEN_1_TINT);
+		case 2:
+			if (dark == true)
+				return tint_color(color, B_LIGHTEN_1_TINT);
+			else
+				return tint_color(color, B_DARKEN_2_TINT);
+		case 3: // intentional fallthrough
+		case 4:
+			if (dark == true)
+				return tint_color(color, B_LIGHTEN_2_TINT);
+			else
+				return tint_color(color, B_DARKEN_3_TINT);
+		default:
+			if (dark == true)
+				return tint_color(color, B_LIGHTEN_2_TINT - 0.1f);
+			else
+				return tint_color(color, B_DARKEN_4_TINT);
+	}
+}
+
+
+float
+FontHeight(const BView* view)
+{
+	if (!view)
+		return 0.0;
+	BFont font;
+	view->GetFont(&font);
+	font_height fheight;
+	font.GetHeight(&fheight);
+	return ceilf(fheight.ascent + fheight.descent + fheight.leading);
 }

--- a/src/CalendarView.h
+++ b/src/CalendarView.h
@@ -1,6 +1,9 @@
 /*
- * Copyright 2017 Jadedctrl
+ * Copyright 2007-2011, Haiku, Inc. All Rights Reserved.
+ * Copyright 2020-2021 Jaidyn Levesque, jadedctrl@teknik.io
  * All rights reserved. Distributed under the terms of the MIT license.
+ * Authors:
+ *		Julun <host.haiku@gmx.de>
  */
 #ifndef CALENDAR_VIEW_H
 #define CALENDAR_VIEW_H
@@ -29,7 +32,16 @@ public:
 		void			DrawDay(BView*, BRect, const char*, bool, bool, bool, bool);
 private:
 		void			_Init();
+		void			_DrawItem(BView* owner, BRect frame, const char* text,
+							bool isHighlight, bool focus, rgb_color bgColor,
+							rgb_color textColor);
+
 		QueryDBManager*	fDBManager;
 };
+
+
+rgb_color	TintColor(rgb_color color, rgb_color base, int severity);
+float		FontHeight(const BView* view);
+
 
 #endif


### PR DESCRIPTION
Days with events are highlighted with a tinted color based on how many events are scheduled for that day, heatmap-style.
An attempt at #106.

Busy days have their backgrounds set to a tinted B_LIST_BACKGROUND_COLOR, the current highlight color, varying based on the amount of events (with four different tints: 1, 2, 3-4, 5+).

I ended up changing the selection color to B_LINK_ACTIVE_COLOR, since the tinted backgrounds are a bittt close to B_LIST_SELECTED_BACKGROUND_COLOR in the "Haiku" theme.

![haiku](https://user-images.githubusercontent.com/10477760/142929922-7b309143-283d-49f3-9634-a075f2c914c3.png)
![dark-flat](https://user-images.githubusercontent.com/10477760/142929935-4d76a178-3193-4d69-994e-84b43393c8d0.png)
![moz-modern](https://user-images.githubusercontent.com/10477760/142929940-eb91f8df-5170-4ea0-98b7-58c6eadeeacb.png)
