### PR TITLE
Save current tab and mode, keyboard shortcuts

### DIFF
--- a/src/EventListView.h
+++ b/src/EventListView.h
@@ -39,6 +39,7 @@ private:
 	static const int32 kHideActionInvoked	= 1003;
 
 	void			_ShowPopUpMenu(BPoint screen);
+	void			_ShowEmptyPopUpMenu(BPoint screen);
 
 	bool			fShowingPopUpMenu;
 	bool			fPopUpMenuEnabled;

--- a/src/EventTabView.cpp
+++ b/src/EventTabView.cpp
@@ -28,7 +28,7 @@ EventTabView::EventTabView(const BDate& date)
 	_AddEventList("Week", B_TRANSLATE("Week"), kWeekTab);
 	_AddEventList("Month", B_TRANSLATE("Month"), kMonthTab);
 
-	fMode = 0;
+	fMode = ((App*)be_app)->GetPreferences()->fViewMode;
 	fPopUpEnabled = true;
 	fEventList = new BList();
 	fDBManager = new QueryDBManager();
@@ -39,8 +39,8 @@ EventTabView::EventTabView(const BDate& date)
 void
 EventTabView::AttachedToWindow()
 {
-	if (Selection() < 0)
-		Select(0);
+	Select(((App*)be_app)->GetPreferences()->fSelectedTab);
+	Window()->MessageReceived(new BMessage(kListModeChanged));
 
 	EventListView* list = ListAt(Selection());
 	if (list != NULL)
@@ -154,6 +154,8 @@ EventTabView::Select(int32 index)
 	ListAt(index)->SetPopUpMenuEnabled(fPopUpEnabled);
 	LoadEvents();
 
+	((App*)be_app)->GetPreferences()->fSelectedTab = index;
+	((App*)be_app)->GetPreferences()->fViewMode = fMode;
 	Window()->MessageReceived(new BMessage(kListTabChanged));
 }
 
@@ -172,6 +174,7 @@ EventTabView::ToggleMode(uint8 flag)
 	fMode ^= flag;
 	_PopulateList();
 
+	((App*)be_app)->GetPreferences()->fViewMode = fMode;
 	Window()->MessageReceived(new BMessage(kListModeChanged));
 }
 

--- a/src/EventTabView.h
+++ b/src/EventTabView.h
@@ -48,6 +48,7 @@ public:
 	virtual void	Select(int32 index);
 
 			void	SetDate(const BDate& date);
+
 			void	ToggleMode(uint8 flag);
 			uint8	Mode();
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -74,7 +74,7 @@ MainWindow::MessageReceived(BMessage* message)
 		case kMenuAppQuit:
 			be_app->PostMessage(B_QUIT_REQUESTED);
 			break;
-		case kAddEvent:
+		case kAddEventMessage:
 			_LaunchEventManager(NULL);
 			break;
 		case kEditEventMessage:
@@ -231,10 +231,12 @@ MainWindow::_InitInterface()
 	fMenuBar = new BMenuBar("MenuBar");
 
 	fAppMenu = new BMenu(B_TRANSLATE("App"));
-	BMenuItem* item = new BMenuItem(B_TRANSLATE("About"), new BMessage(B_ABOUT_REQUESTED));
+	BMenuItem* item = new BMenuItem(B_TRANSLATE("About" B_UTF8_ELLIPSIS),
+		new BMessage(B_ABOUT_REQUESTED));
 	item->SetTarget(be_app);
 	fAppMenu->AddItem(item);
-	fAppMenu->AddItem(new BMenuItem(B_TRANSLATE("Preferences"), new BMessage(kMenuAppPref)));
+	fAppMenu->AddItem(new BMenuItem(B_TRANSLATE("Settings" B_UTF8_ELLIPSIS),
+		new BMessage(kMenuAppPref), ',', B_COMMAND_KEY));
 	//
 	// Google Calendar support is broken.  It should be replaced with a generic solution to
 	// be able to sync with various calendars.  Leaving this here for now to give future
@@ -244,19 +246,25 @@ MainWindow::_InitInterface()
 	//fSyncMenu->AddItem(new BMenuItem(B_TRANSLATE("Google Calendar"), new BMessage(kMenuSyncGCAL)));
 	//fAppMenu->AddItem(fSyncMenu);
 	fAppMenu->AddSeparatorItem();
-	fAppMenu->AddItem(new BMenuItem(B_TRANSLATE("Quit"), new BMessage(kMenuAppQuit), 'Q', B_COMMAND_KEY));
+	fAppMenu->AddItem(new BMenuItem(B_TRANSLATE("Quit"), new BMessage(kMenuAppQuit),
+		'Q', B_COMMAND_KEY));
 
 	fEventMenu = new BMenu(B_TRANSLATE("Event"));
-	fEventMenu->AddItem(new BMenuItem(B_TRANSLATE("Add event"), new BMessage(kAddEvent)));
-	fEventMenu->AddItem(new BMenuItem(B_TRANSLATE("Edit event"), new BMessage(kEditEventMessage)));
-	fEventMenu->AddItem(new BMenuItem(B_TRANSLATE("Remove event"), new BMessage(kDeleteEventMessage)));
-	fEventMenu->AddItem(new BMenuItem(B_TRANSLATE("Cancel event"), new BMessage(kCancelEventMessage)));
-	fEventMenu->AddItem(new BMenuItem(B_TRANSLATE("Hide event"), new BMessage(kHideEventMessage)));
+	fEventMenu->AddItem(new BMenuItem(B_TRANSLATE_CONTEXT("New" B_UTF8_ELLIPSIS, "EventListView"),
+		new BMessage(kAddEventMessage), 'N', B_COMMAND_KEY));
+	fEventMenu->AddItem(new BMenuItem(B_TRANSLATE_CONTEXT("Edit" B_UTF8_ELLIPSIS, "EventListView"),
+		new BMessage(kEditEventMessage), 'E', B_COMMAND_KEY));
+	fEventMenu->AddItem(new BMenuItem(B_TRANSLATE_CONTEXT("Delete", "EventListView"),
+		new BMessage(kDeleteEventMessage), 'T', B_COMMAND_KEY));
+	fEventMenu->AddItem(new BMenuItem(B_TRANSLATE_CONTEXT("Cancel", "EventListView"),
+		new BMessage(kCancelEventMessage)));
+	fEventMenu->AddItem(new BMenuItem(B_TRANSLATE_CONTEXT("Hide", "EventListView"),
+		new BMessage(kHideEventMessage)));
 	for (int i = 1; i < fEventMenu->CountItems(); i++)
 		fEventMenu->ItemAt(i)->SetEnabled(false);
 
 	fCategoryMenu = new BMenu(B_TRANSLATE("Category"));
-	fCategoryMenu->AddItem(new BMenuItem(B_TRANSLATE("Manage categories" B_UTF8_ELLIPSIS),
+	fCategoryMenu->AddItem(new BMenuItem(B_TRANSLATE("Manage" B_UTF8_ELLIPSIS),
 		new BMessage(kMenuCategoryEdit)));
 
 	BMessage* agendaMsg = new BMessage(kChangeListMode);
@@ -272,10 +280,11 @@ MainWindow::_InitInterface()
 	monthMsg->AddInt32("tab", kMonthTab);
 
 	fViewMenu = new BMenu(B_TRANSLATE("View"));
-	fViewMenu->AddItem(new BMenuItem(B_TRANSLATE("Day view"), dayMsg));
-	fViewMenu->AddItem(new BMenuItem(B_TRANSLATE("Week view"), weekMsg));
-	fViewMenu->AddItem(new BMenuItem(B_TRANSLATE("Month view"), monthMsg));
+	fViewMenu->AddItem(new BMenuItem(B_TRANSLATE_CONTEXT("Day", "DayView"), dayMsg));
+	fViewMenu->AddItem(new BMenuItem(B_TRANSLATE_CONTEXT("Week", "DayView"), weekMsg));
+	fViewMenu->AddItem(new BMenuItem(B_TRANSLATE_CONTEXT("Month", "DayView"), monthMsg));
 	fViewMenu->AddSeparatorItem();
+
 	fViewMenu->AddItem(new BMenuItem(B_TRANSLATE("Agenda mode"), agendaMsg));
 	fViewMenu->AddItem(new BMenuItem(B_TRANSLATE("Show hidden/deleted events"), hiddenMsg));
 	fViewMenu->AddSeparatorItem();

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -24,6 +24,8 @@ static const uint32 kMenuAppPref = 'kmap';
 static const uint32 kMenuCategoryEdit = 'kmce';
 static const uint32 kMenuSyncGCAL = 'kmsg';
 
+static const int 	kAddEventMessage = 1005;
+
 
 class MainWindow: public BWindow {
 public:
@@ -43,7 +45,6 @@ private:
 	void			_ToggleEventMenu(BMessage* msg);
 
 	static const int	kMenuAppQuit		= 1000;
-	static const int 	kAddEvent 		= 1005;
 
 
 	MainView*		fMainView;

--- a/src/PreferenceWindow.cpp
+++ b/src/PreferenceWindow.cpp
@@ -29,7 +29,7 @@
 #define B_TRANSLATION_CONTEXT "PreferenceWindow"
 
 PreferenceWindow::PreferenceWindow(Preferences* preferences)
-	:BWindow(BRect(), B_TRANSLATE("Preferences"), B_TITLED_WINDOW,
+	:BWindow(BRect(), B_TRANSLATE("Settings"), B_TITLED_WINDOW,
 		B_NOT_ZOOMABLE | B_NOT_RESIZABLE| B_AUTO_UPDATE_SIZE_LIMITS)
 {
 	fCurrentPreferences = preferences;

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -65,6 +65,8 @@ Preferences::Load(const char* filename)
 	if(result == B_OK)
 		storage.Unflatten(file);
 	fStartOfWeekOffset = storage.GetInt32("startOfWeekOffset", 0);
+	fSelectedTab = storage.GetInt32("selectedTab", 0);
+	fViewMode = storage.GetInt32("viewMode", 0);
 	fHeaderVisible = storage.GetBool("headerVisible", false);
 	fFirstDeletion = storage.GetBool("firstDeletion", true);
 	fDefaultCategory = storage.GetString("defaultCategory", B_TRANSLATE("Default"));
@@ -122,6 +124,8 @@ Preferences::Save(const char* filename)
 
 	BMessage storage;
 	storage.AddInt32("startOfWeekOffset", fStartOfWeekOffset);
+	storage.AddInt32("selectedTab", fSelectedTab);
+	storage.AddInt32("viewMode", fViewMode);
 	storage.AddBool("headerVisible", fHeaderVisible);
 	storage.AddBool("firstDeletion", fFirstDeletion);
 	storage.AddString("defaultCategory", fDefaultCategory);

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -7,9 +7,6 @@
 #ifndef PREFERENCES_H
 #define PREFERENCES_H
 
-
-#include <string>
-
 #include <Path.h>
 #include <String.h>
 
@@ -24,13 +21,13 @@ public:
 	BPath					fSettingsPath;
 
 	int32					fStartOfWeekOffset;
+	int32					fViewMode;
+	int32					fSelectedTab;
 	bool					fHeaderVisible;
+	bool					fFirstDeletion;
 	BString					fDefaultCategory;
 	BRect					fMainWindowRect;
 	BRect					fEventWindowRect;
-
-	bool					fFirstDeletion;
 };
-
 
 #endif


### PR DESCRIPTION
Just saves the current tab (week/month/day) and mode (agenda/show hidden), and adds keyboard shortcuts to the menubar items for Add/Edit/Delete-- changing Delete from ALT-D to ALT-T, to be a little more in-line with Tracker. Also adds an "Add event" item to the event list's context menu when nothing is selected.