### PR TITLE
Use newly-exported libshared DateTimeEdit controls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ SRCS = \
 	 src/CategoryListItem.cpp \
 	 src/CalendarMenuWindow.cpp  \
 	 src/DateHeaderButton.cpp  \
+	 src/DateTimeEdit.cpp  \
 	 src/EventListView.cpp  \
 	 src/EventListItem.cpp  \
 	 src/EventTabView.cpp  \

--- a/src/DateTimeEdit.cpp
+++ b/src/DateTimeEdit.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2004-2011, Haiku, Inc. All Rights Reserved.
+ * Copyright 2017 Akshay Agarwal, agarwal.akshay.akshay8@gmail.com
+ * Copyright 2022, Jaidyn Levesque, jadedctrl@teknik.io
+ * All rights reserved. Distributed under the terms of the MIT license.
+ *
+ * Authors:
+ *		Axel Dörfler <axeld@pinc-software.de>
+ *		Hamish Morrison <hamish@lavabit.com>
+ *		Julun <host.haiku@gmx.de>
+ *		Mike Berg <mike@berg-net.us>
+ */
+
+#include "DateTimeEdit.h"
+
+#include <ControlLook.h>
+
+#include "CalendarMenuWindow.h"
+
+
+const uint32 kArrowAreaWidth = 16;
+const int32 kCalendarMenuDate = 'cald';
+
+
+DateEdit::DateEdit(const char* name, BMessage* message)
+	:
+	BPrivate::DateEdit(name, 3, message)
+{
+}
+
+
+void
+DateEdit::MessageReceived(BMessage* message)
+{
+	if (message->what == kCalendarMenuDate) {
+		int32 day, month, year;
+		if (message->FindInt32("day", &day) == B_OK
+			&& message->FindInt32("month", &month) == B_OK
+			&& message->FindInt32("year", &year) == B_OK)
+			SetDate(year, month, day);
+	} else
+		BPrivate::DateEdit::MessageReceived(message);
+}
+
+
+void
+DateEdit::MouseDown(BPoint where)
+{
+	if (fCalendarButton.Contains(where) && IsEnabled()) {
+		if (fCalendarWindow.IsValid()) {
+			BMessage activate(B_SET_PROPERTY);
+			activate.AddSpecifier("Active");
+			activate.AddBool("data", true);
+			if (fCalendarWindow.SendMessage(&activate) == B_OK)
+				return;
+		}
+
+		CalendarMenuWindow* window =
+			new CalendarMenuWindow(this, ConvertToScreen(fCalendarPoint));
+		window->SetInvocationMessage(new BMessage(kCalendarMenuDate));
+		window->SetDate(GetDate());
+		fCalendarWindow = BMessenger(window);
+
+		BPoint centeredCalendarPt = ConvertToScreen(fCalendarPoint);
+		centeredCalendarPt.x -= window->Frame().Width();
+		window->MoveTo(centeredCalendarPt);
+		window->Show();
+	} else
+		BPrivate::DateEdit::MouseDown(where);
+}
+
+
+void
+DateEdit::Draw(BRect updateRect)
+{
+	if (IsEnabled())
+		SetViewUIColor(B_DOCUMENT_BACKGROUND_COLOR);
+	else
+		SetViewUIColor(B_PANEL_BACKGROUND_COLOR);
+
+	SetLowColor(ViewColor());
+	FillRect(updateRect, B_SOLID_LOW);
+	BPrivate::DateEdit::Draw(updateRect);
+}
+
+
+void
+DateEdit::DrawBorder(const BRect& updateRect)
+{
+	BRect bounds(Bounds());
+	bool showFocus = (IsFocus() && Window() && Window()->IsActive());
+
+	be_control_look->DrawBorder(this, bounds, updateRect, ViewColor(),
+		B_FANCY_BORDER, showFocus ? BControlLook::B_FOCUSED : 0);
+
+	// Instead of the up-down arrows, draw a "this opens something up" arrow
+	bounds.left = bounds.right - kArrowAreaWidth;
+	bounds.right = Bounds().right - 2;
+	if (!updateRect.Intersects(bounds))
+		return;
+
+	const float vertMargin = 6;
+	const float horizMargin = 3;
+	BPoint left(bounds.left + horizMargin, bounds.top + vertMargin);
+	BPoint right(bounds.right - horizMargin, bounds.top + vertMargin);
+	BPoint middle(bounds.left + floorf(bounds.Width() / 2), bounds.bottom - vertMargin);
+
+	fCalendarButton = bounds;
+	fCalendarPoint = middle;
+
+	FillRect(bounds, B_SOLID_LOW);
+	FillTriangle(left, right, middle, B_SOLID_HIGH);
+}
+
+
+TimeEdit::TimeEdit(const char* name, BMessage* message)
+	:
+	BPrivate::TimeEdit(name, 3, message)
+{
+	BFormattingConventions conventions;
+	BLocale().GetFormattingConventions(&conventions);
+	if (conventions.Use24HourClock() == false)
+		fSectionCount = 4;
+}
+
+
+void
+TimeEdit::Draw(BRect updateRect)
+{
+	if (IsEnabled())
+		SetViewUIColor(B_DOCUMENT_BACKGROUND_COLOR);
+	else
+		SetViewUIColor(B_PANEL_BACKGROUND_COLOR);
+
+	SetLowColor(ViewColor());
+	FillRect(updateRect, B_SOLID_LOW);
+	BPrivate::TimeEdit::Draw(updateRect);
+}

--- a/src/DateTimeEdit.h
+++ b/src/DateTimeEdit.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2004-2011, Haiku, Inc. All Rights Reserved.
+ * Copyright 2022, Jaidyn Levesque, jadedctrl@teknik.io
+ * All rights reserved. Distributed under the terms of the MIT license.
+ */
+#ifndef DATE_EDIT_H
+#define DATE_EDIT_H
+
+#include <DateTimeEdit.h>
+#include <Messenger.h>
+
+
+class DateEdit : public BPrivate::DateEdit {
+public:
+					DateEdit(const char* name, BMessage* message = NULL);
+
+	virtual void	MessageReceived(BMessage* message);
+
+	virtual void	MouseDown(BPoint where);
+
+	virtual void	Draw(BRect updateRect);
+
+protected:
+	virtual void	DrawBorder(const BRect& updateRect);
+
+private:
+	BMessenger fCalendarWindow;
+	BRect fCalendarButton;
+	BPoint fCalendarPoint;
+};
+
+
+class TimeEdit : public BPrivate::TimeEdit {
+public:
+					TimeEdit(const char* name, BMessage* message = NULL);
+
+	virtual void	Draw(BRect updateRect);
+};
+
+#endif // DATE_EDIT_H

--- a/src/EventWindow.h
+++ b/src/EventWindow.h
@@ -1,12 +1,13 @@
 /*
- * Copyight 2017 Akshay Agarwal, agarwal.akshay.akshay8@gmail.com
+ * Copyright 2017 Akshay Agarwal, agarwal.akshay.akshay8@gmail.com
+ * Copyright 2022 Jaidyn Levesque, jadedctrl@teknik.io
  * All rights reserved. Distributed under the terms of the MIT License.
  */
 #ifndef EVENTWINDOW_H
 #define EVENTWINDOW_H
 
 #include <DateTime.h>
-#include <Messenger.h>
+#include <TimeZone.h>
 #include <Window.h>
 
 #include "Category.h"
@@ -23,9 +24,11 @@ class BTextControl;
 class BTextView;
 class BView;
 class Category;
+class DateEdit;
 class Event;
 class Preferences;
 class QueryDBManager;
+class TimeEdit;
 
 
 static const uint32 kEventWindowQuitting = 'kewq';
@@ -54,16 +57,11 @@ public:
 	void			OnDeleteClick();
 	void			CloseWindow();
 
-	BString			GetDateString(BDate& date);
-	BString			GetLocaleTimeString(time_t timeValue);
-	void			GetDateFromMessage(BMessage* message, BDate& date);
-
 private:
 	void			_InitInterface();
 	void			_PopulateWithEvent(Event* event);
 	void			_DisableControls();
 	void			_UpdateCategoryMenu();
-	void			_ShowPopUpCalendar(int8 which);
 
 	static const uint32 kDeletePressed = 1000;
 	static const uint32 kCancelPressed = 1001;
@@ -74,18 +72,16 @@ private:
 
 	BTextControl*	fTextName;
 	BTextControl*	fTextPlace;
-	BTextControl*	fTextStartDate;
-	BTextControl*	fTextEndDate;
-	BTextControl*	fTextStartTime;
-	BTextControl*	fTextEndTime;
+
+	DateEdit*	fStartDateEdit;
+	DateEdit*	fEndDateEdit;
+	TimeEdit*	fStartTimeEdit;
+	TimeEdit*	fEndTimeEdit;
 
 	BTextView*		fTextDescription;
 	BView*			fMainView;
 
 	BMenu*			fCategoryMenu;
-	BMenu*			fStartDateEdit;
-	BMenu*			fEndDateEdit;
-
 	BMenuField*		fCategoryMenuField;
 
 	BStringView*	fNameLabel;
@@ -93,14 +89,8 @@ private:
 	BStringView*	fDescriptionLabel;
 	BStringView*	fCategoryLabel;
 	BStringView*	fAllDayLabel;
-	BStringView*	fStartDateLabel;
-	BStringView*	fStartTimeLabel;
-	BStringView*	fEndDateLabel;
-	BStringView*	fEndTimeLabel;
 
 	BButton*		fDeleteButton;
-	BButton*		fStartCalButton;
-	BButton*		fEndCalButton;
 
 	BRadioButton*	fEveryMonth;
 	BRadioButton*	fEveryYear;
@@ -113,10 +103,7 @@ private:
 	BBox*			fEndDateBox;
 	BBox*			fStatusBox;
 
-	BMessenger		fCalendarWindow;
-
-	BDate			fStartDate;
-	BDate			fEndDate;
+	BTimeZone		fTimeZone;
 
 	bool			fNew;
 


### PR DESCRIPTION
Just swaps out the text controls with the exported DateEdit and TimeEdit.
![datetime](https://user-images.githubusercontent.com/10477760/170855905-b939e82d-c20e-41d6-8dae-d90fd40810ce.png)
