### PR TITLE
BMessageRunner set up in daemon

### DIFF
--- a/daemon/src/CalendarDaemon.cpp
+++ b/daemon/src/CalendarDaemon.cpp
@@ -82,8 +82,12 @@ CalendarDaemon::ReadyToRun()
 		notifyMessage->AddInt64("deltaTime", event->GetStartDateTime() - event->GetReminderTime());
 
 		fMessageRunner = new BMessageRunner(be_app_messenger, notifyMessage, timeout, 1);
+		delete(notifyMessage);
 		if (fMessageRunner->InitCheck() != B_OK)
 			std::cout << "MessageRunner Not Initialized!\n";
+
+		std::cout << "Reminder is set for: " << event->GetName() << std::endl;
+		std::cout << "And is going off in " << timeout/1000000 << " seconds" << std::endl;
 	}
 }
 
@@ -107,7 +111,6 @@ CalendarDaemon::MessageReceived(BMessage *message)
 			int32 opCode;
 			ino_t node;
 			message->FindInt32("opcode", &opCode);
-			message->FindInt64("node", &node);
 
 			switch (opCode) {
 				case B_ENTRY_CREATED:
@@ -144,6 +147,10 @@ CalendarDaemon::MessageReceived(BMessage *message)
 				notifyMessage->AddInt64("deltaTime", event->GetStartDateTime() - event->GetReminderTime());
 
 				fMessageRunner->StartSending(be_app_messenger, notifyMessage, timeout, 1);
+				delete(notifyMessage);
+
+				std::cout << "Reminder is set for: " << event->GetName() << std::endl;
+				std::cout << "And is going off in " << timeout/1000000 << " seconds" << std::endl;
 			}
 		} break;
 		case B_QUIT_REQUESTED:
@@ -219,6 +226,10 @@ CalendarDaemon::RefreshEventList()
 		notifyMessage->AddInt64("deltaTime", event->GetStartDateTime() - event->GetReminderTime());
 
 		fMessageRunner->StartSending(be_app_messenger, notifyMessage, timeout, 1);
+		delete(notifyMessage);
+
+		std::cout << "Reminder is set for: " << event->GetName() << std::endl;
+		std::cout << "And is going off in " << timeout/1000000 << " seconds" << std::endl;
 	}
 }
 

--- a/daemon/src/CalendarDaemon.cpp
+++ b/daemon/src/CalendarDaemon.cpp
@@ -134,6 +134,7 @@ CalendarDaemon::MessageReceived(BMessage *message)
 
 			fEventList->RemoveItemAt((int32)0);
 			ShowEvents();
+			delete(fMessageRunner);
 			
 			if (fEventList->CountItems() > 0) {
 				Event* event = fEventList->ItemAt(0);
@@ -145,7 +146,7 @@ CalendarDaemon::MessageReceived(BMessage *message)
 				notifyMessage.AddString("place", event->GetPlace());
 				notifyMessage.AddInt64("deltaTime", event->GetStartDateTime() - event->GetReminderTime());
 
-				fMessageRunner->StartSending(be_app_messenger, &notifyMessage, timeout, 1);
+				fMessageRunner = new BMessageRunner(be_app_messenger, &notifyMessage, timeout, 1);
 
 				std::cout << "Reminder is set for: " << event->GetName() << std::endl;
 				std::cout << "And is going off in " << timeout/1000000 << " seconds" << std::endl;
@@ -223,7 +224,7 @@ CalendarDaemon::RefreshEventList()
 		notifyMessage.AddString("place", event->GetPlace());
 		notifyMessage.AddInt64("deltaTime", event->GetStartDateTime() - event->GetReminderTime());
 
-		fMessageRunner->StartSending(be_app_messenger, &notifyMessage, timeout, 1);
+		fMessageRunner = new BMessageRunner(be_app_messenger, &notifyMessage, timeout, 1);
 
 		std::cout << "Reminder is set for: " << event->GetName() << std::endl;
 		std::cout << "And is going off in " << timeout/1000000 << " seconds" << std::endl;

--- a/daemon/src/CalendarDaemon.cpp
+++ b/daemon/src/CalendarDaemon.cpp
@@ -76,13 +76,12 @@ CalendarDaemon::ReadyToRun()
 		bigtime_t timeout;		
 		timeout = (event->GetReminderTime() - real_time_clock()) * 1000000;
 		
-		BMessage* notifyMessage = new BMessage(kEventNotify);
-		notifyMessage->AddString("name", event->GetName());
-		notifyMessage->AddString("place", event->GetPlace());
-		notifyMessage->AddInt64("deltaTime", event->GetStartDateTime() - event->GetReminderTime());
+		BMessage notifyMessage(kEventNotify);
+		notifyMessage.AddString("name", event->GetName());
+		notifyMessage.AddString("place", event->GetPlace());
+		notifyMessage.AddInt64("deltaTime", event->GetStartDateTime() - event->GetReminderTime());
 
-		fMessageRunner = new BMessageRunner(be_app_messenger, notifyMessage, timeout, 1);
-		delete(notifyMessage);
+		fMessageRunner = new BMessageRunner(be_app_messenger, &notifyMessage, timeout, 1);
 		if (fMessageRunner->InitCheck() != B_OK)
 			std::cout << "MessageRunner Not Initialized!\n";
 
@@ -141,13 +140,12 @@ CalendarDaemon::MessageReceived(BMessage *message)
 				bigtime_t timeout;		
 				timeout = (event->GetReminderTime() - real_time_clock()) * 1000000;
 
-				BMessage* notifyMessage = new BMessage(kEventNotify);
-				notifyMessage->AddString("name", event->GetName());
-				notifyMessage->AddString("place", event->GetPlace());
-				notifyMessage->AddInt64("deltaTime", event->GetStartDateTime() - event->GetReminderTime());
+				BMessage notifyMessage(kEventNotify);
+				notifyMessage.AddString("name", event->GetName());
+				notifyMessage.AddString("place", event->GetPlace());
+				notifyMessage.AddInt64("deltaTime", event->GetStartDateTime() - event->GetReminderTime());
 
-				fMessageRunner->StartSending(be_app_messenger, notifyMessage, timeout, 1);
-				delete(notifyMessage);
+				fMessageRunner->StartSending(be_app_messenger, &notifyMessage, timeout, 1);
 
 				std::cout << "Reminder is set for: " << event->GetName() << std::endl;
 				std::cout << "And is going off in " << timeout/1000000 << " seconds" << std::endl;
@@ -220,13 +218,12 @@ CalendarDaemon::RefreshEventList()
 		bigtime_t timeout;		
 		timeout = (event->GetReminderTime() - real_time_clock()) * 1000000;
 
-		BMessage* notifyMessage = new BMessage(kEventNotify);
-		notifyMessage->AddString("name", event->GetName());
-		notifyMessage->AddString("place", event->GetPlace());
-		notifyMessage->AddInt64("deltaTime", event->GetStartDateTime() - event->GetReminderTime());
+		BMessage notifyMessage(kEventNotify);
+		notifyMessage.AddString("name", event->GetName());
+		notifyMessage.AddString("place", event->GetPlace());
+		notifyMessage.AddInt64("deltaTime", event->GetStartDateTime() - event->GetReminderTime());
 
-		fMessageRunner->StartSending(be_app_messenger, notifyMessage, timeout, 1);
-		delete(notifyMessage);
+		fMessageRunner->StartSending(be_app_messenger, &notifyMessage, timeout, 1);
 
 		std::cout << "Reminder is set for: " << event->GetName() << std::endl;
 		std::cout << "And is going off in " << timeout/1000000 << " seconds" << std::endl;

--- a/daemon/src/CalendarDaemon.cpp
+++ b/daemon/src/CalendarDaemon.cpp
@@ -7,10 +7,13 @@
 
 #include <iostream>
 
+#include <Alert.h>
+#include <Catalog.h>
 #include <Directory.h>
 #include <FindDirectory.h>
 #include <NodeMonitor.h>
 #include <Path.h>
+#include <StringFormat.h>
 #include <VolumeRoster.h>
 
 #define EVENT_DIRECTORY "config/settings/Calendar/events"
@@ -69,6 +72,20 @@ CalendarDaemon::CalendarDaemon()
 	fEventList = fDBManager.GetEventsToNotify(BDateTime::CurrentDateTime(B_LOCAL_TIME));
 	fEventList->SortItems(_CompareFunction);
 	ShowEvents();
+
+	if (fEventList->CountItems() > 0) {
+		Event* event = fEventList->ItemAt(0);
+		bigtime_t timeout;		
+		timeout = (event->GetReminderTime() - real_time_clock()) * 1000000;
+		
+		BMessage* notifyMessage = new BMessage(kEventNotify);
+		notifyMessage->AddString("name", event->GetName());
+		notifyMessage->AddString("place", event->GetPlace());
+		notifyMessage->AddInt64("deltaTime", event->GetStartDateTime() - event->GetReminderTime());
+
+		BMessageRunner fMessageRunner(this, notifyMessage, 2, -1);
+		std::cout << "\nEvent " << event->GetName() << " going off in " << timeout/100000 << " seconds\n";
+	}
 }
 
 
@@ -76,6 +93,7 @@ CalendarDaemon::~CalendarDaemon()
 {
 	std::cout << "Stopping Daemon, Good Bye! ;)" << std::endl;
 	stop_watching(be_app_messenger);
+	delete(fEventList);
 }
 
 
@@ -102,6 +120,33 @@ CalendarDaemon::MessageReceived(BMessage *message)
 			}
 			break;
 		}
+		case kEventNotify: {
+			const char* name;
+			const char* place;
+			time_t deltaTime;
+			message->FindString("name", &name);
+			message->FindString("place", &place);
+			message->FindInt64("deltaTime", &deltaTime);
+
+			// SendAlert(name, place, deltaTime);
+			SendAlert("fuck", "yes", 69);
+
+			fEventList->RemoveItemAt((int32)0);
+			
+			if (fEventList->CountItems() > 0) {
+				Event* event = fEventList->ItemAt(0);
+				bigtime_t timeout;		
+				timeout = (event->GetReminderTime() - real_time_clock()) * 1000000;
+
+				BMessage* notifyMessage = new BMessage(kEventNotify);
+				notifyMessage->AddString("name", event->GetName());
+				notifyMessage->AddString("place", event->GetPlace());
+				notifyMessage->AddInt64("deltaTime", event->GetStartDateTime() - event->GetReminderTime());
+
+				BMessageRunner fMessageRunner(this, notifyMessage, timeout, -1);
+				std::cout << "\nEvent " << event->GetName() << " going off in " << timeout << " seconds\n";
+			}
+		} break;
 		case B_QUIT_REQUESTED:
 			QuitRequested();
 			break;
@@ -109,6 +154,43 @@ CalendarDaemon::MessageReceived(BMessage *message)
 			BApplication::MessageReceived(message);
 			break;
 	}
+}
+
+
+void
+CalendarDaemon::SendAlert(const char* name, const char* place, time_t deltaTime)
+{
+	BString alertText(B_TRANSLATE("Calendar notification!\n\n"
+		"Event:\t%eventName%\n"
+		"Place:\t%eventPlace%\n\n"
+		"The event starts in "));
+
+	alertText.ReplaceAll("%eventName%", name);
+	alertText.ReplaceAll("%eventPlace%", place);
+ 
+	if (deltaTime%3600 == 0) {
+		deltaTime /= 3600;
+		static BStringFormat format(B_TRANSLATE("{0, plural,"
+		"=1{1 hour!}"
+		"other{# hours!}}"));
+		format.Format(alertText, deltaTime);
+	} else if (deltaTime%60 == 0) {
+		deltaTime /= 60;
+		static BStringFormat format(B_TRANSLATE("{0, plural,"
+		"=1{1 minute!}"
+		"other{# minutes!}}"));
+		format.Format(alertText, deltaTime);
+	} else {
+		static BStringFormat format(B_TRANSLATE("{0, plural,"
+		"=1{1 second!}"
+		"other{# seconds!}}"));
+		format.Format(alertText, deltaTime);
+	}
+	BAlert* alert = new BAlert("Reminder!", alertText.String(),
+					"OK", NULL, NULL, B_WIDTH_AS_USUAL,
+					B_OFFSET_SPACING, B_WARNING_ALERT);
+	alert->SetShortcut(0, B_ESCAPE);
+	alert->Go();
 }
 
 

--- a/daemon/src/CalendarDaemon.h
+++ b/daemon/src/CalendarDaemon.h
@@ -13,11 +13,6 @@
 
 #include "QueryDBManager.h"
 
-enum
-{
-	kEventNotify,
-};
-
 /*!
 	CalendarDaemon Class Declaration
 */

--- a/daemon/src/CalendarDaemon.h
+++ b/daemon/src/CalendarDaemon.h
@@ -31,6 +31,7 @@ public:
 
 	void			MessageReceived(BMessage* message);
 	bool			QuitRequested();
+	void			ReadyToRun();
 
 	void			WatchEvent(entry_ref* ref);
 	void			UnwatchEvent(entry_ref* ref);
@@ -46,7 +47,7 @@ private:
 	BVolume				fQueryVolume;
 	EventList*			fEventList;
 	QueryDBManager		fDBManager;
-	//BMessageRunner		fMessageRunner;
+	BMessageRunner*		fMessageRunner;
 };
 
 #endif

--- a/daemon/src/CalendarDaemon.h
+++ b/daemon/src/CalendarDaemon.h
@@ -7,10 +7,16 @@
 #define CALENDAR_DAEMON_H
 
 #include <Application.h>
+#include <MessageRunner.h>
 #include <OS.h>
 #include <Volume.h>
 
 #include "QueryDBManager.h"
+
+enum
+{
+	kEventNotify,
+};
 
 /*!
 	CalendarDaemon Class Declaration
@@ -30,6 +36,7 @@ public:
 	void			UnwatchEvent(entry_ref* ref);
 	void			ShowEvents();
 	void			RefreshEventList();
+	void			SendAlert(const char* name, const char* place, time_t deltaTime);
 
 private:
 
@@ -39,7 +46,7 @@ private:
 	BVolume				fQueryVolume;
 	EventList*			fEventList;
 	QueryDBManager		fDBManager;
-	
+	//BMessageRunner		fMessageRunner;
 };
 
 #endif


### PR DESCRIPTION
For issue: #122 

Scope of PR: Set up BMessageRunner to get alerts at the right time

I'm having some difficulty in setting up the BMesageRunner. It currently is not working as (I think) it is, a local variable in the constructor. And it gets destroyed when the constructor completes.
Do we need to have it as class member, or is it not necessary? Can we set it up under BApplication (Somehow?) 
It's a bit confusing as the documentation also does not provide any pointer regarding this.

Also please look at the code, am I in the right direction with this approach?