### PR TITLE
userlaunch file created

### DIFF
--- a/daemon/CalendarDaemon_userlaunch
+++ b/daemon/CalendarDaemon_userlaunch
@@ -1,0 +1,5 @@
+service x-vnd.CalendarDaemon { 
+	if setting ~/config/settings/Calendar/Daemon/Daemon_settings autostart
+	no_safemode
+	legacy
+}


### PR DESCRIPTION
For issue: #130 

Scope of the PR: To write the configuration file for the daemon, so that it can be started automatically by the launch_daemon when the system boots up, or when the daemon has closed/crashed.